### PR TITLE
add the run subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+python

--- a/go.mod
+++ b/go.mod
@@ -13,5 +13,6 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
+	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
 	google.golang.org/grpc v1.37.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -611,6 +611,7 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45minvA9aorojkyjGk9KJ5B/w=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -754,6 +755,7 @@ golang.org/x/sys v0.0.0-20201202213521-69691e467435/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492 h1:Paq34FxTluEPvVyayQqMPgHm+vTOrIifmcYxFBx9TLg=
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/package_list.hcl
+++ b/package_list.hcl
@@ -13,4 +13,6 @@ package "python" {
         source="/usr/local/lib/python3.9/site-packages/"
         dest="./python/packages/"
     }
+
+    port="3000"
 }

--- a/subcommands/run_sc.go
+++ b/subcommands/run_sc.go
@@ -1,0 +1,144 @@
+package subcommands
+
+import (
+	"errors"
+	"flag"
+	"os"
+	"strconv"
+
+	"github.com/everettraven/packageless/utils"
+)
+
+//Run Sub-Command Object
+type RunCommand struct {
+	//FlagSet so that we can create a custom flag
+	fs *flag.FlagSet
+
+	//String for the name of the package to run
+	name string
+
+	args []string
+}
+
+//Instantiation method for a new RunCommand
+func NewRunCommand() *RunCommand {
+	//Create a new RunCommand and set the FlagSet
+	rc := &RunCommand{
+		fs: flag.NewFlagSet("run", flag.ContinueOnError),
+	}
+
+	return rc
+}
+
+//Name - Gets the name of the Sub-Command
+func (rc *RunCommand) Name() string {
+	return rc.fs.Name()
+}
+
+//Init - Parses and Populates values of the Run subcommand
+func (rc *RunCommand) Init(args []string) error {
+
+	if len(args) <= 0 {
+		return errors.New("No package name was found. You must include the name of the package you wish to run.")
+	}
+
+	rc.name = args[0]
+
+	// if len(args) > 1 {
+	// 	rc.args = args[1:]
+	// }
+
+	rc.args = args[1:]
+
+	return nil
+}
+
+//Run - Runs the Run subcommand
+func (rc *RunCommand) Run() error {
+	//Create variables to use later
+	var found bool
+	var pack utils.Package
+
+	//Default location of the package list
+	packageList := "./package_list.hcl"
+
+	//Config file location
+	configLoc := "./config.hcl"
+
+	//Parse the package list
+	parseOut, err := utils.Parse(packageList, utils.PackageHCLUtil{})
+
+	//Check for errors
+	if err != nil {
+		return err
+	}
+
+	packages := parseOut.(utils.PackageHCLUtil)
+
+	//Parse the config file
+	parseOut, err = utils.Parse(configLoc, utils.Config{})
+
+	//Check for errors
+	if err != nil {
+		return err
+	}
+
+	config := parseOut.(utils.Config)
+
+	//Look for the package we want in the package list
+	for _, packs := range packages.Packages {
+		//If we find it, set some variables and break
+		if packs.Name == rc.name {
+			found = true
+			pack = packs
+			break
+		}
+	}
+
+	//Make sure we have found the package in the package list
+	if !found {
+		return errors.New("Could not find package " + rc.name + " in the package list")
+	}
+
+	//Check if the corresponding package image is already Runed
+	imgExist, err := utils.ImageExists(pack.Image)
+
+	//Check for errors
+	if err != nil {
+		return err
+	}
+
+	//If the image exists the package is already Runed
+	if !imgExist {
+		return errors.New("Package " + pack.Name + "is not installed. You must install the package before running it.")
+	}
+
+	//Create the variables to use when running the container
+	var ports []string
+	var volumes []string
+
+	ports = append(ports, strconv.Itoa(config.StartPort)+":"+pack.Port)
+
+	for _, vol := range pack.Volumes {
+		if vol.Path != "" {
+			volumes = append(volumes, vol.Path+":"+vol.Mount)
+		} else {
+			sourcePath, err := os.Getwd()
+
+			if err != nil {
+				return err
+			}
+
+			volumes = append(volumes, sourcePath+":"+vol.Mount)
+		}
+	}
+
+	//Run the container
+	err = utils.RunContainer(pack.Image, ports, volumes, pack.Name, rc.args)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/subcommands/subcommand.go
+++ b/subcommands/subcommand.go
@@ -22,6 +22,7 @@ func SubCommand(args []string) error {
 	cmds := []Runner{
 		NewInstallCommand(),
 		NewUpgradeCommand(),
+		NewRunCommand(),
 	}
 
 	subcommand := os.Args[1]

--- a/subcommands/upgrade_sc.go
+++ b/subcommands/upgrade_sc.go
@@ -9,18 +9,18 @@ import (
 	"github.com/everettraven/packageless/utils"
 )
 
-//Install Sub-Command Object
+//Upgrade Sub-Command Object
 type UpgradeCommand struct {
 	//FlagSet so that we can create a custom flag
 	fs *flag.FlagSet
 
-	//String for the name of the package to install
+	//String for the name of the package to upgrade
 	name string
 }
 
-//Instantiation method for a new InstallCommand
+//Instantiation method for a new UpgradeCommand
 func NewUpgradeCommand() *UpgradeCommand {
-	//Create a new InstallCommand and set the FlagSet
+	//Create a new UpgradeCommand and set the FlagSet
 	ic := &UpgradeCommand{
 		fs: flag.NewFlagSet("upgrade", flag.ContinueOnError),
 	}
@@ -33,10 +33,10 @@ func (ic *UpgradeCommand) Name() string {
 	return ic.fs.Name()
 }
 
-//Init - Parses and Populates values of the Install subcommand
+//Init - Parses and Populates values of the Upgrade subcommand
 func (ic *UpgradeCommand) Init(args []string) error {
 	if len(args) <= 0 {
-		fmt.Println("No package specified, upgrading all currently installed packages.")
+		fmt.Println("No package specified, upgrading all currently Upgradeed packages.")
 	} else {
 		ic.name = args[0]
 		fmt.Println("Upgrading", ic.name)
@@ -44,7 +44,7 @@ func (ic *UpgradeCommand) Init(args []string) error {
 	return nil
 }
 
-//Run - Runs the install subcommand
+//Run - Runs the Upgrade subcommand
 func (ic *UpgradeCommand) Run() error {
 	//Create variables to use later
 	var found bool
@@ -79,7 +79,7 @@ func (ic *UpgradeCommand) Run() error {
 			return errors.New("Could not find package " + ic.name + " in the package list")
 		}
 
-		//Check if the corresponding package image is already installed
+		//Check if the corresponding package image is already Upgradeed
 		imgExist, err := utils.ImageExists(pack.Image)
 
 		//Check for errors
@@ -87,9 +87,9 @@ func (ic *UpgradeCommand) Run() error {
 			return err
 		}
 
-		//If the image exists the package is already installed
+		//If the image exists the package is already Upgradeed
 		if !imgExist {
-			return errors.New("Package: " + pack.Name + " is not installed. It must be installed before it can be upgraded.")
+			return errors.New("Package: " + pack.Name + " is not Upgradeed. It must be Upgradeed before it can be upgraded.")
 		}
 
 		fmt.Println("Upgrading", pack.Name)
@@ -169,7 +169,7 @@ func (ic *UpgradeCommand) Run() error {
 	} else {
 		//Loop through the packages in the package list
 		for _, pack := range packages.Packages {
-			//Check if the corresponding package image is already installed
+			//Check if the corresponding package image is already Upgradeed
 			imgExist, err := utils.ImageExists(pack.Image)
 
 			//Check for errors
@@ -177,7 +177,7 @@ func (ic *UpgradeCommand) Run() error {
 				return err
 			}
 
-			//If the image exists the package is already installed
+			//If the image exists the package is already Upgradeed
 			if !imgExist {
 				continue
 			}

--- a/utils/hcl_parse.go
+++ b/utils/hcl_parse.go
@@ -25,6 +25,7 @@ type Package struct {
 	Image   string   `hcl:"image,attr"`
 	Volumes []Volume `hcl:"volume,block"`
 	Copies  []*Copy  `hcl:"copy,block"`
+	Port    string   `hcl:"port,optional"`
 }
 
 //PackageHCLUtil object to contain a list of packages and all their attributes after the parsing of the package list


### PR DESCRIPTION
Add the run subcommand to run packages. Adding the run functionality so that configuration changes can be made and are reflected when running the docker containers. when using the run functionality a command is run rather than interfacing with the Docker Go SDK as it is easier to create an interactive container by utilizing the docker CLI