### PR TITLE
add alias handling during install and uninstall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .vscode
 python
+packageless.exe
+macros.doskey

--- a/go.mod
+++ b/go.mod
@@ -14,5 +14,6 @@ require (
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
+	golang.org/x/sys v0.0.0-20210324051608-47abb6519492 // indirect
 	google.golang.org/grpc v1.37.1 // indirect
 )

--- a/package_list.hcl
+++ b/package_list.hcl
@@ -1,9 +1,9 @@
 package "python" {
     image="packageless/python"
-    base_dir="./python/"
+    base_dir="/python/"
     
     volume {
-        path="./python/packages/"
+        path="/python/packages/"
         mount="/usr/local/lib/python3.9/site-packages/"
     }
 
@@ -13,7 +13,7 @@ package "python" {
 
     copy {
         source="/usr/local/lib/python3.9/site-packages/"
-        dest="./python/packages/"
+        dest="/python/packages/"
     }
 
     port="3000"

--- a/subcommands/run_sc.go
+++ b/subcommands/run_sc.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"flag"
 	"os"
+	"path/filepath"
 	"strconv"
 
 	"github.com/everettraven/packageless/utils"
@@ -59,11 +60,18 @@ func (rc *RunCommand) Run() error {
 	var found bool
 	var pack utils.Package
 
+	//Create a variable for the executable directory
+	ex, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	ed := filepath.Dir(ex)
+
 	//Default location of the package list
-	packageList := "./package_list.hcl"
+	packageList := ed + "/package_list.hcl"
 
 	//Config file location
-	configLoc := "./config.hcl"
+	configLoc := ed + "/config.hcl"
 
 	//Parse the package list
 	parseOut, err := utils.Parse(packageList, utils.PackageHCLUtil{})
@@ -121,7 +129,7 @@ func (rc *RunCommand) Run() error {
 
 	for _, vol := range pack.Volumes {
 		if vol.Path != "" {
-			volumes = append(volumes, vol.Path+":"+vol.Mount)
+			volumes = append(volumes, ed+vol.Path+":"+vol.Mount)
 		} else {
 			sourcePath, err := os.Getwd()
 

--- a/subcommands/uninstall_sc.go
+++ b/subcommands/uninstall_sc.go
@@ -1,10 +1,14 @@
 package subcommands
 
 import (
+	"bufio"
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
+	"runtime"
 
 	"github.com/everettraven/packageless/utils"
 )
@@ -51,8 +55,15 @@ func (uc *UninstallCommand) Run() error {
 	var found bool
 	var pack utils.Package
 
+	//Create a variable for the executable directory
+	ex, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	ed := filepath.Dir(ex)
+
 	//Default location of the package list
-	packageList := "./package_list.hcl"
+	packageList := ed + "/package_list.hcl"
 
 	//Parse the package list
 	parseOut, err := utils.Parse(packageList, utils.PackageHCLUtil{})
@@ -106,7 +117,7 @@ func (uc *UninstallCommand) Run() error {
 	for _, vol := range pack.Volumes {
 		//Make sure that a path is given.
 		if vol.Path != "" {
-			err = RemoveDir(vol.Path)
+			err = RemoveDir(ed + vol.Path)
 
 			if err != nil {
 				return err
@@ -115,7 +126,14 @@ func (uc *UninstallCommand) Run() error {
 	}
 
 	//Remove the base directory for the package
-	err = RemoveDir(pack.BaseDir)
+	err = RemoveDir(ed + pack.BaseDir)
+
+	if err != nil {
+		return err
+	}
+
+	//Remove aliases
+	err = RemoveAlias(pack.Name, ed)
 
 	if err != nil {
 		return err
@@ -144,5 +162,187 @@ func RemoveDir(path string) error {
 		err = os.RemoveAll(path)
 	}
 
+	return nil
+}
+
+//Remove Alias will remove the alias for the specified package name from the corresponding files
+func RemoveAlias(name string, ed string) error {
+	//If runtime is on windows remove from macros.doskey and the powershell profile files
+	if runtime.GOOS == "windows" {
+
+		//Command Prompt
+		//------------------------------------------------
+		//Open the doskey file
+		file, err := os.OpenFile(ed+"/macros.doskey", os.O_RDWR, 0755)
+
+		var newOut []string
+
+		if err != nil {
+			return err
+		}
+
+		reader := bufio.NewReader(file)
+
+		//Read the file line by line
+		for {
+			line, err := reader.ReadString('\n')
+
+			//Check for EOF
+			if err != nil && err == io.EOF {
+				break
+			}
+
+			if err != nil {
+				return err
+			}
+
+			dos := name + "=" + ed + "/packageless run " + name + "\n"
+
+			//if the line is the doskey for this package dont include it in the new file
+			if line != dos {
+				newOut = append(newOut, line)
+			}
+		}
+
+		//Close the file
+		file.Close()
+
+		//Recreate the doskey file
+		newFile, err := os.OpenFile(ed+"/macros.doskey", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+
+		if err != nil {
+			return err
+		}
+
+		//Write the contents back to the doskey file
+		for _, line := range newOut {
+			_, err = newFile.WriteString(line)
+
+			if err != nil {
+				return err
+			}
+		}
+
+		//Close the file
+		newFile.Close()
+
+		//------------------------------------------------
+
+		//PowerShell
+		//------------------------------------------------
+
+		pwshPath := os.Getenv("USERPROFILE") + "/Documents/WindowsPowerShell/"
+
+		//Open the powershell profile file
+		file, err = os.OpenFile(pwshPath+"Microsoft.PowerShell_profile.ps1", os.O_RDWR, 0755)
+
+		//Reset the newOut array
+		newOut = nil
+
+		if err != nil {
+			return err
+		}
+
+		reader = bufio.NewReader(file)
+
+		//Read the file line by line
+		for {
+			line, err := reader.ReadString('\n')
+
+			//Check for EOF
+			if err != nil && err == io.EOF {
+				break
+			}
+
+			if err != nil {
+				return err
+			}
+
+			alias := "function " + name + "(){ " + ed + "\\packageless.exe run " + name + " }\n"
+
+			//if the line is the alias for this package dont include it in the new file
+			if line != alias {
+				newOut = append(newOut, line)
+			}
+		}
+
+		//Close the file
+		file.Close()
+
+		//Recreate the powershell profile file
+		newFile, err = os.OpenFile(pwshPath+"Microsoft.PowerShell_profile.ps1", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+
+		if err != nil {
+			return err
+		}
+
+		//Write the contents back to the powershell profile file
+		for _, line := range newOut {
+			_, err = newFile.WriteString(line)
+
+			if err != nil {
+				return err
+			}
+		}
+
+		//Close the file
+		newFile.Close()
+
+	} else {
+		//If it isnt windows, remove it from the bash aliases file
+		file, err := os.OpenFile("~/.bash_aliases", os.O_RDWR, 0755)
+
+		var newOut []string
+
+		if err != nil {
+			return err
+		}
+
+		reader := bufio.NewReader(file)
+
+		//Read the file line by line
+		for {
+			line, err := reader.ReadString('\n')
+
+			//Check for EOF
+			if err != nil && err == io.EOF {
+				break
+			}
+
+			if err != nil {
+				return err
+			}
+
+			alias := "alias " + name + "=" + "\"" + ed + "/packageless run " + name + "\"" + "\n"
+
+			//if the line is the alias for this package dont include it in the new file
+			if line != alias {
+				newOut = append(newOut, line)
+			}
+		}
+
+		//Close the file
+		file.Close()
+
+		//Recreate the bash aliases file
+		newFile, err := os.OpenFile("~/.bash_aliases", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+
+		if err != nil {
+			return err
+		}
+
+		//Write the contents back to the bash aliases file
+		for _, line := range newOut {
+			_, err = newFile.WriteString(line)
+
+			if err != nil {
+				return err
+			}
+		}
+
+		//Close the file
+		newFile.Close()
+
+	}
 	return nil
 }

--- a/subcommands/upgrade_sc.go
+++ b/subcommands/upgrade_sc.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/everettraven/packageless/utils"
 )
@@ -50,8 +51,15 @@ func (ic *UpgradeCommand) Run() error {
 	var found bool
 	var pack utils.Package
 
+	//Create a variable for the executable directory
+	ex, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	ed := filepath.Dir(ex)
+
 	//Default location of the package list
-	packageList := "./package_list.hcl"
+	packageList := ed + "/package_list.hcl"
 
 	//Parse the package list
 	parseOut, err := utils.Parse(packageList, utils.PackageHCLUtil{})
@@ -106,9 +114,9 @@ func (ic *UpgradeCommand) Run() error {
 		for _, vol := range pack.Volumes {
 			//Make sure that a path is given. If not we already assume that the working directory will be mounted
 			if vol.Path != "" {
-				if _, err := os.Stat(vol.Path); err != nil {
+				if _, err := os.Stat(ed + vol.Path); err != nil {
 					if os.IsNotExist(err) {
-						err = os.MkdirAll(vol.Path, 0755)
+						err = os.MkdirAll(ed+vol.Path, 0755)
 
 						if err != nil {
 							return err
@@ -118,14 +126,14 @@ func (ic *UpgradeCommand) Run() error {
 					}
 				} else {
 					//Remove the directory if it already exists
-					err = os.RemoveAll(vol.Path)
+					err = os.RemoveAll(ed + vol.Path)
 
 					if err != nil {
 						return err
 					}
 
 					//Recreate the directory
-					err = os.MkdirAll(vol.Path, 0755)
+					err = os.MkdirAll(ed+vol.Path, 0755)
 
 					if err != nil {
 						return err
@@ -148,7 +156,7 @@ func (ic *UpgradeCommand) Run() error {
 			fmt.Println("Copying necessary files 2/3")
 			//Copy the files from the container to the locations
 			for _, copy := range pack.Copies {
-				err = utils.CopyFromContainer(copy.Source, copy.Dest, containerID)
+				err = utils.CopyFromContainer(copy.Source, ed+copy.Dest, containerID)
 
 				if err != nil {
 					return err
@@ -196,9 +204,9 @@ func (ic *UpgradeCommand) Run() error {
 			for _, vol := range pack.Volumes {
 				//Make sure that a path is given. If not we already assume that the working directory will be mounted
 				if vol.Path != "" {
-					if _, err := os.Stat(vol.Path); err != nil {
+					if _, err := os.Stat(ed + vol.Path); err != nil {
 						if os.IsNotExist(err) {
-							err = os.MkdirAll(vol.Path, 0755)
+							err = os.MkdirAll(ed+vol.Path, 0755)
 
 							if err != nil {
 								return err
@@ -208,14 +216,14 @@ func (ic *UpgradeCommand) Run() error {
 						}
 					} else {
 						//Remove the directory if it already exists
-						err = os.RemoveAll(vol.Path)
+						err = os.RemoveAll(ed + vol.Path)
 
 						if err != nil {
 							return err
 						}
 
 						//Recreate the directory
-						err = os.MkdirAll(vol.Path, 0755)
+						err = os.MkdirAll(ed+vol.Path, 0755)
 
 						if err != nil {
 							return err
@@ -238,7 +246,7 @@ func (ic *UpgradeCommand) Run() error {
 				fmt.Println("Copying necessary files 2/3")
 				//Copy the files from the container to the locations
 				for _, copy := range pack.Copies {
-					err = utils.CopyFromContainer(copy.Source, copy.Dest, containerID)
+					err = utils.CopyFromContainer(copy.Source, ed+copy.Dest, containerID)
 
 					if err != nil {
 						return err


### PR DESCRIPTION
Added aliasing for both command prompt and powershell on windows. both command prompt and powershell have been tested on a windows 10 machine.

Added aliasing for bash. bash has not been tested on a UNIX machine yet.

running the install subcommand will add the aliases and uninstall will remove them.