### PR TITLE
update aliases

### DIFF
--- a/subcommands/alias_unix.go
+++ b/subcommands/alias_unix.go
@@ -1,0 +1,90 @@
+// +build linux
+package subcommands
+
+import (
+	"bufio"
+	"io"
+	"os"
+)
+
+//AddAlias will add the alias for the package name specified
+func AddAliasUnix(name string, ed string) error {
+	//If run on linux lets modify the bash aliases file to include the new aliases
+	file, err := os.OpenFile("~/.bash_aliases", os.O_CREATE|os.O_APPEND, 0755)
+
+	if err != nil {
+		return err
+	}
+
+	//Create the alias and write it to the file
+	alias := "alias " + name + "=" + "\"" + ed + "/packageless run " + name + "\"" + "\n"
+
+	_, err = file.WriteString(alias)
+
+	if err != nil {
+		return err
+	}
+
+	file.Close()
+
+	return nil
+}
+
+//Remove Alias will remove the alias for the specified package name from the corresponding files
+func RemoveAliasUnix(name string, ed string) error {
+	//If it isnt windows, remove it from the bash aliases file
+	file, err := os.OpenFile("~/.bash_aliases", os.O_RDWR, 0755)
+
+	var newOut []string
+
+	if err != nil {
+		return err
+	}
+
+	reader := bufio.NewReader(file)
+
+	//Read the file line by line
+	for {
+		line, err := reader.ReadString('\n')
+
+		//Check for EOF
+		if err != nil && err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return err
+		}
+
+		alias := "alias " + name + "=" + "\"" + ed + "/packageless run " + name + "\"" + "\n"
+
+		//if the line is the alias for this package dont include it in the new file
+		if line != alias {
+			newOut = append(newOut, line)
+		}
+	}
+
+	//Close the file
+	file.Close()
+
+	//Recreate the bash aliases file
+	newFile, err := os.OpenFile("~/.bash_aliases", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+
+	if err != nil {
+		return err
+	}
+
+	//Write the contents back to the bash aliases file
+	for _, line := range newOut {
+		_, err = newFile.WriteString(line)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	//Close the file
+	newFile.Close()
+
+	return nil
+}

--- a/subcommands/alias_unix.go
+++ b/subcommands/alias_unix.go
@@ -1,4 +1,3 @@
-// +build linux
 package subcommands
 
 import (

--- a/subcommands/alias_win.go
+++ b/subcommands/alias_win.go
@@ -1,4 +1,3 @@
-// +build windows
 package subcommands
 
 import (

--- a/subcommands/alias_win.go
+++ b/subcommands/alias_win.go
@@ -1,0 +1,106 @@
+// +build windows
+package subcommands
+
+import (
+	"bufio"
+	"io"
+	"os"
+)
+
+//AddAlias will add the alias for the package name specified
+func AddAliasWin(name string, ed string) error {
+	//Set the alias for Powershell
+	//--------------------------------
+	pwshPath := os.Getenv("USERPROFILE") + "/Documents/WindowsPowerShell/"
+
+	//Create the powershell directory if it doesnt exist
+	err := MakeDir(pwshPath)
+
+	if err != nil {
+		return err
+	}
+
+	//Open the powershell alias file
+	file, err := OpenFile(pwshPath + "Microsoft.PowerShell_profile.ps1")
+
+	if err != nil {
+		return err
+	}
+
+	alias := "function " + name + "(){ " + ed + "\\packageless.exe run " + name + " $args }\n"
+
+	_, err = file.WriteString(alias)
+
+	if err != nil {
+		return err
+	}
+
+	file.Close()
+
+	return nil
+}
+
+//Remove Alias will remove the alias for the specified package name from the corresponding files
+func RemoveAliasWin(name string, ed string) error {
+	//PowerShell
+	//------------------------------------------------
+
+	pwshPath := os.Getenv("USERPROFILE") + "/Documents/WindowsPowerShell/"
+
+	//Open the powershell profile file
+	file, err := os.OpenFile(pwshPath+"Microsoft.PowerShell_profile.ps1", os.O_RDWR, 0755)
+
+	//Create the newOut array
+	var newOut []string
+
+	if err != nil {
+		return err
+	}
+
+	reader := bufio.NewReader(file)
+
+	//Read the file line by line
+	for {
+		line, err := reader.ReadString('\n')
+
+		//Check for EOF
+		if err != nil && err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return err
+		}
+
+		alias := "function " + name + "(){ " + ed + "\\packageless.exe run " + name + " }\n"
+
+		//if the line is the alias for this package dont include it in the new file
+		if line != alias {
+			newOut = append(newOut, line)
+		}
+	}
+
+	//Close the file
+	file.Close()
+
+	//Recreate the powershell profile file
+	newFile, err := os.OpenFile(pwshPath+"Microsoft.PowerShell_profile.ps1", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+
+	if err != nil {
+		return err
+	}
+
+	//Write the contents back to the powershell profile file
+	for _, line := range newOut {
+		_, err = newFile.WriteString(line)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	//Close the file
+	newFile.Close()
+
+	return nil
+}

--- a/subcommands/install_sc.go
+++ b/subcommands/install_sc.go
@@ -8,8 +8,6 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"golang.org/x/sys/windows/registry"
-
 	"github.com/everettraven/packageless/utils"
 )
 
@@ -166,7 +164,11 @@ func (ic *InstallCommand) Run() error {
 	//Set the alias for the command
 	fmt.Println("Setting Alias")
 
-	err = AddAlias(pack.Name, ed)
+	if runtime.GOOS == "windows" {
+		err = AddAliasWin(pack.Name, ed)
+	} else {
+		err = AddAliasUnix(pack.Name, ed)
+	}
 
 	if err != nil {
 		return err
@@ -215,90 +217,4 @@ func OpenFile(path string) (*os.File, error) {
 	}
 
 	return file, nil
-}
-
-//AddAlias will add the alias for the package name specified
-func AddAlias(name string, ed string) error {
-	//Check what the os is
-	if runtime.GOOS == "windows" {
-		//Set the alias for CMD
-		//------------------------------------------
-		//Open the doskey file
-		file, err := OpenFile(ed + "/macros.doskey")
-
-		//Write the doskey to the doskey file
-		dos := name + "=" + ed + "/packageless run " + name + "\n"
-
-		_, err = file.WriteString(dos)
-
-		if err != nil {
-			return err
-		}
-
-		//Create the registry key
-		k, _, err := registry.CreateKey(registry.CURRENT_USER, `SOFTWARE\Microsoft\Command Processor`, registry.SET_VALUE)
-
-		if err != nil {
-			return err
-		}
-
-		//Set the registry key value
-		err = k.SetStringValue("Autorun", "doskey /macrofile="+"\""+ed+"/macros.doskey\"")
-
-		if err != nil {
-			return err
-		}
-
-		file.Close()
-		//--------------------------------
-
-		//Set the alias for Powershell
-		//--------------------------------
-		pwshPath := os.Getenv("USERPROFILE") + "/Documents/WindowsPowerShell/"
-
-		//Create the powershell directory if it doesnt exist
-		err = MakeDir(pwshPath)
-
-		if err != nil {
-			return err
-		}
-
-		//Open the powershell alias file
-		file, err = OpenFile(pwshPath + "Microsoft.PowerShell_profile.ps1")
-
-		if err != nil {
-			return err
-		}
-
-		alias := "function " + name + "(){ " + ed + "\\packageless.exe run " + name + " }\n"
-
-		_, err = file.WriteString(alias)
-
-		if err != nil {
-			return err
-		}
-
-		file.Close()
-
-	} else {
-		//If run on linux lets modify the bash aliases file to include the new aliases
-		file, err := os.OpenFile("~/.bash_aliases", os.O_CREATE|os.O_APPEND, 0755)
-
-		if err != nil {
-			return err
-		}
-
-		//Create the alias and write it to the file
-		alias := "alias " + name + "=" + "\"" + ed + "/packageless run " + name + "\"" + "\n"
-
-		_, err = file.WriteString(alias)
-
-		if err != nil {
-			return err
-		}
-
-		file.Close()
-	}
-
-	return nil
 }


### PR DESCRIPTION
Update the process of creating aliases.
- Removed Command Prompt support (just use powershell instead)
- Different functions for windows and linux alias setting
- Updated PowerShell alias to include passing arguments