### PR TITLE
make setting alias optional

### DIFF
--- a/config.hcl
+++ b/config.hcl
@@ -1,3 +1,4 @@
 base_dir="./"
 start_port=3000
 port_increment=1
+alias=true

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/everettraven/packageless/subcommands"
 	"github.com/everettraven/packageless/utils"
@@ -25,12 +26,37 @@ func wrappedMain() (int, error) {
 	//Create the copier for the subcommands
 	cp := &utils.CopyTool{}
 
+	//Create a variable for the executable directory
+	ex, err := os.Executable()
+	if err != nil {
+		return 1, err
+	}
+	ed := filepath.Dir(ex)
+
+	//Config file location
+	configLoc := ed + "/config.hcl"
+
+	configBody, err := util.GetHCLBody(configLoc)
+
+	if err != nil {
+		return 1, err
+	}
+
+	//Parse the config file
+	parseOut, err := util.ParseBody(configBody, utils.Config{})
+
+	if err != nil {
+		return 1, err
+	}
+
+	config := parseOut.(utils.Config)
+
 	//Create the list of subcommands
 	scmds := []subcommands.Runner{
-		subcommands.NewInstallCommand(util, cp),
-		subcommands.NewUninstallCommand(util),
+		subcommands.NewInstallCommand(util, cp, config),
+		subcommands.NewUninstallCommand(util, config),
 		subcommands.NewUpgradeCommand(util, cp),
-		subcommands.NewRunCommand(util),
+		subcommands.NewRunCommand(util, config),
 	}
 
 	//Run the subcommands

--- a/subcommands/install_sc.go
+++ b/subcommands/install_sc.go
@@ -24,15 +24,18 @@ type InstallCommand struct {
 	tools utils.Tools
 
 	cp utils.Copier
+
+	config utils.Config
 }
 
 //Instantiation method for a new InstallCommand
-func NewInstallCommand(tools utils.Tools, cp utils.Copier) *InstallCommand {
+func NewInstallCommand(tools utils.Tools, cp utils.Copier, config utils.Config) *InstallCommand {
 	//Create a new InstallCommand and set the FlagSet
 	ic := &InstallCommand{
-		fs:    flag.NewFlagSet("install", flag.ContinueOnError),
-		tools: tools,
-		cp:    cp,
+		fs:     flag.NewFlagSet("install", flag.ContinueOnError),
+		tools:  tools,
+		cp:     cp,
+		config: config,
 	}
 
 	return ic
@@ -180,17 +183,19 @@ func (ic *InstallCommand) Run() error {
 
 	}
 
-	//Set the alias for the command
-	fmt.Println("Setting Alias")
+	if ic.config.Alias {
+		//Set the alias for the command
+		fmt.Println("Setting Alias")
 
-	if runtime.GOOS == "windows" {
-		err = ic.tools.AddAliasWin(pack.Name, ed)
-	} else {
-		err = ic.tools.AddAliasUnix(pack.Name, ed)
-	}
+		if runtime.GOOS == "windows" {
+			err = ic.tools.AddAliasWin(pack.Name, ed)
+		} else {
+			err = ic.tools.AddAliasUnix(pack.Name, ed)
+		}
 
-	if err != nil {
-		return err
+		if err != nil {
+			return err
+		}
 	}
 
 	fmt.Println(pack.Name, "successfully installed")

--- a/subcommands/install_sc_test.go
+++ b/subcommands/install_sc_test.go
@@ -15,7 +15,14 @@ func TestInstallName(t *testing.T) {
 
 	mcp := &utils.MockCopyTool{}
 
-	ic := NewInstallCommand(mu, mcp)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     true,
+	}
+
+	ic := NewInstallCommand(mu, mcp, config)
 
 	if ic.Name() != "install" {
 		t.Fatal("The install subcommand's name should be: install | Subcommand Name: " + ic.Name())
@@ -28,7 +35,14 @@ func TestInstallInit(t *testing.T) {
 
 	mcp := &utils.MockCopyTool{}
 
-	ic := NewInstallCommand(mu, mcp)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     true,
+	}
+
+	ic := NewInstallCommand(mu, mcp, config)
 
 	args := []string{"python"}
 
@@ -58,7 +72,14 @@ func TestInstallFlow(t *testing.T) {
 
 	mcp := &utils.MockCopyTool{}
 
-	ic := NewInstallCommand(mu, mcp)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     true,
+	}
+
+	ic := NewInstallCommand(mu, mcp, config)
 
 	args := []string{"python"}
 
@@ -174,7 +195,14 @@ func TestInstallErrorAtGetHCLBody(t *testing.T) {
 
 	mcp := &utils.MockCopyTool{}
 
-	ic := NewInstallCommand(mu, mcp)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     true,
+	}
+
+	ic := NewInstallCommand(mu, mcp, config)
 
 	args := []string{"python"}
 
@@ -213,7 +241,14 @@ func TestInstallErrorAtParseBody(t *testing.T) {
 
 	mcp := &utils.MockCopyTool{}
 
-	ic := NewInstallCommand(mu, mcp)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     true,
+	}
+
+	ic := NewInstallCommand(mu, mcp, config)
 
 	args := []string{"python"}
 
@@ -253,7 +288,14 @@ func TestInstallErrorAtImageExists(t *testing.T) {
 
 	mcp := &utils.MockCopyTool{}
 
-	ic := NewInstallCommand(mu, mcp)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     true,
+	}
+
+	ic := NewInstallCommand(mu, mcp, config)
 
 	args := []string{"python"}
 
@@ -294,7 +336,14 @@ func TestInstallErrorAtPullImage(t *testing.T) {
 
 	mcp := &utils.MockCopyTool{}
 
-	ic := NewInstallCommand(mu, mcp)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     true,
+	}
+
+	ic := NewInstallCommand(mu, mcp, config)
 
 	args := []string{"python"}
 
@@ -336,7 +385,14 @@ func TestInstallErrorAtMakeDir(t *testing.T) {
 
 	mcp := &utils.MockCopyTool{}
 
-	ic := NewInstallCommand(mu, mcp)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     true,
+	}
+
+	ic := NewInstallCommand(mu, mcp, config)
 
 	args := []string{"python"}
 
@@ -379,7 +435,14 @@ func TestInstallErrorAtCreateContainer(t *testing.T) {
 
 	mcp := &utils.MockCopyTool{}
 
-	ic := NewInstallCommand(mu, mcp)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     true,
+	}
+
+	ic := NewInstallCommand(mu, mcp, config)
 
 	args := []string{"python"}
 
@@ -424,7 +487,14 @@ func TestInstallErrorAtCopyFromContainer(t *testing.T) {
 
 	mcp := &utils.MockCopyTool{}
 
-	ic := NewInstallCommand(mu, mcp)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     true,
+	}
+
+	ic := NewInstallCommand(mu, mcp, config)
 
 	args := []string{"python"}
 
@@ -470,7 +540,14 @@ func TestInstallErrorAtRemoveContainer(t *testing.T) {
 
 	mcp := &utils.MockCopyTool{}
 
-	ic := NewInstallCommand(mu, mcp)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     true,
+	}
+
+	ic := NewInstallCommand(mu, mcp, config)
 
 	args := []string{"python"}
 
@@ -517,7 +594,14 @@ func TestInstallErrorAtAddAlias(t *testing.T) {
 
 	mcp := &utils.MockCopyTool{}
 
-	ic := NewInstallCommand(mu, mcp)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     true,
+	}
+
+	ic := NewInstallCommand(mu, mcp, config)
 
 	args := []string{"python"}
 
@@ -567,7 +651,14 @@ func TestInstallImageExists(t *testing.T) {
 
 	mcp := &utils.MockCopyTool{}
 
-	ic := NewInstallCommand(mu, mcp)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     true,
+	}
+
+	ic := NewInstallCommand(mu, mcp, config)
 
 	args := []string{"python"}
 
@@ -607,7 +698,14 @@ func TestInstallNoPackage(t *testing.T) {
 
 	mcp := &utils.MockCopyTool{}
 
-	ic := NewInstallCommand(mu, mcp)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     true,
+	}
+
+	ic := NewInstallCommand(mu, mcp, config)
 
 	args := []string{}
 
@@ -628,7 +726,14 @@ func TestInstallNonExistPackage(t *testing.T) {
 
 	mcp := &utils.MockCopyTool{}
 
-	ic := NewInstallCommand(mu, mcp)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     true,
+	}
+
+	ic := NewInstallCommand(mu, mcp, config)
 
 	args := []string{"nonexistent"}
 
@@ -659,4 +764,124 @@ func TestInstallNonExistPackage(t *testing.T) {
 	if !reflect.DeepEqual(callStack, mu.Calls) {
 		t.Fatalf("Call Stack does not match the expected call stack. Call Stack: %v | Expected Call Stack: %v", mu.Calls, callStack)
 	}
+}
+
+//Test if the config has the Alias property set to false
+func TestInstallAliasFalse(t *testing.T) {
+	mu := utils.NewMockUtility()
+
+	//Get the executable directory
+	ex, err := os.Executable()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ed := filepath.Dir(ex)
+
+	mcp := &utils.MockCopyTool{}
+
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     false,
+	}
+
+	ic := NewInstallCommand(mu, mcp, config)
+
+	args := []string{"python"}
+
+	err = ic.Init(args)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ic.Run()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//Set a variable with the proper call stack and see if the call stack matches
+	callStack := []string{
+		"GetHCLBody",
+		"ParseBody",
+		"ImageExists",
+		"PullImage",
+		"MakeDir",
+		"MakeDir",
+		"CreateContainer",
+		"CopyFromContainer",
+		"RemoveContainer",
+	}
+
+	//If the call stack doesn't match the test fails
+	if !reflect.DeepEqual(callStack, mu.Calls) {
+		t.Fatalf("Call Stack does not match the expected call stack. Call Stack: %v | Expected Call Stack: %v", mu.Calls, callStack)
+	}
+
+	//Make a list of images that should have been pulled and make sure it matches from the MockUtility
+	var images []string
+
+	//Lists of copy data
+	var copySources []string
+	var copyDests []string
+
+	//directories to be created
+	var mkdirs []string
+
+	//Fill lists
+	for _, pack := range mu.Pack.Packages {
+		images = append(images, pack.Image)
+		mkdirs = append(mkdirs, ed+pack.BaseDir)
+
+		//Loop through volumes in the package
+		for _, vol := range pack.Volumes {
+			mkdirs = append(mkdirs, ed+vol.Path)
+		}
+
+		//Loop through the copies in the package
+		for _, copy := range pack.Copies {
+			copySources = append(copySources, copy.Source)
+			copyDests = append(copyDests, ed+copy.Dest)
+		}
+	}
+
+	//If the pulled images doesn't match the test fails
+	if !reflect.DeepEqual(images, mu.PulledImgs) {
+		t.Fatalf("Pulled Images does not match the expected Pulled Images. Pulled Images: %v | Expected Pulled Images: %v", mu.PulledImgs, images)
+	}
+
+	//If the directories made don't match, the test fails
+	if !reflect.DeepEqual(mkdirs, mu.MadeDirs) {
+		t.Fatalf("Made directories does not match the expected directories. Made Directories: %v | Expected Made Directories: %v", mu.MadeDirs, mkdirs)
+	}
+
+	//Make sure that the image passed into the CreateContainer function is correct
+	if !reflect.DeepEqual(mu.CreateImages, images) {
+		t.Fatalf("CreateContainer images does not match the expected images. Images: %v | Expected Images: %v", mu.CreateImages, images)
+	}
+
+	//Make sure the proper ContainerID is being passed into the CopyFromContainer function
+	if mu.CopyContainerID != mu.ContainerID {
+		t.Fatalf("CopyFromContainer ContainerID does not match the expected ContainerID. ContainerID: %s | Expected ContainerID: %s", mu.CopyContainerID, mu.ContainerID)
+	}
+
+	//Ensure that the Copy sources are correct
+	if !reflect.DeepEqual(mu.CopySources, copySources) {
+		t.Fatalf("CopyFromContainer Copy Sources does not match the expected Copy Sources. Copy Sources: %v | Expected Copy Sources: %v", mu.CopySources, copySources)
+	}
+
+	//Ensure that the Copy destinations are correct
+	if !reflect.DeepEqual(mu.CopyDests, copyDests) {
+		t.Fatalf("CopyFromContainer Copy Destinations does not match the expected Copy Destinations. Copy Destinations: %v | Expected Copy Destinations: %v", mu.CopyDests, copyDests)
+	}
+
+	//Ensure that the ContainerID is passed correctly to the RemoveContainer function
+	if mu.RemoveContainerID != mu.ContainerID {
+		t.Fatalf("RemoveContainer ContainerID does not match the expected ContainerID. ContainerID: %s | Expected ContainerID: %s", mu.RemoveContainerID, mu.ContainerID)
+	}
+
 }

--- a/subcommands/run_sc.go
+++ b/subcommands/run_sc.go
@@ -22,14 +22,17 @@ type RunCommand struct {
 	args []string
 
 	tools utils.Tools
+
+	config utils.Config
 }
 
 //Instantiation method for a new RunCommand
-func NewRunCommand(tools utils.Tools) *RunCommand {
+func NewRunCommand(tools utils.Tools, config utils.Config) *RunCommand {
 	//Create a new RunCommand and set the FlagSet
 	rc := &RunCommand{
-		fs:    flag.NewFlagSet("run", flag.ContinueOnError),
-		tools: tools,
+		fs:     flag.NewFlagSet("run", flag.ContinueOnError),
+		tools:  tools,
+		config: config,
 	}
 
 	return rc
@@ -76,16 +79,7 @@ func (rc *RunCommand) Run() error {
 	//Default location of the package list
 	packageList := ed + "/package_list.hcl"
 
-	//Config file location
-	configLoc := ed + "/config.hcl"
-
 	packageListBody, err := rc.tools.GetHCLBody(packageList)
-
-	if err != nil {
-		return err
-	}
-
-	configBody, err := rc.tools.GetHCLBody(configLoc)
 
 	if err != nil {
 		return err
@@ -100,16 +94,6 @@ func (rc *RunCommand) Run() error {
 	}
 
 	packages := parseOut.(utils.PackageHCLUtil)
-
-	//Parse the config file
-	parseOut, err = rc.tools.ParseBody(configBody, utils.Config{})
-
-	//Check for errors
-	if err != nil {
-		return err
-	}
-
-	config := parseOut.(utils.Config)
 
 	//Look for the package we want in the package list
 	for _, packs := range packages.Packages {
@@ -143,7 +127,7 @@ func (rc *RunCommand) Run() error {
 	var ports []string
 	var volumes []string
 
-	ports = append(ports, strconv.Itoa(config.StartPort)+":"+pack.Port)
+	ports = append(ports, strconv.Itoa(rc.config.StartPort)+":"+pack.Port)
 
 	for _, vol := range pack.Volumes {
 		if vol.Path != "" {

--- a/subcommands/run_sc_test.go
+++ b/subcommands/run_sc_test.go
@@ -14,7 +14,14 @@ import (
 func TestRunName(t *testing.T) {
 	mu := utils.NewMockUtility()
 
-	rc := NewRunCommand(mu)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 3000,
+		Alias:     true,
+	}
+
+	rc := NewRunCommand(mu, config)
 
 	if rc.Name() != "run" {
 		t.Fatal("The run subcommand's name should be: run | Subcommand Name: " + rc.Name())
@@ -25,7 +32,14 @@ func TestRunName(t *testing.T) {
 func TestRunInit(t *testing.T) {
 	mu := utils.NewMockUtility()
 
-	rc := NewRunCommand(mu)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 3000,
+		Alias:     true,
+	}
+
+	rc := NewRunCommand(mu, config)
 
 	args := []string{"python"}
 
@@ -46,7 +60,14 @@ func TestRunNoPackage(t *testing.T) {
 
 	expectedErr := "No package name was found. You must include the name of the package you wish to run."
 
-	rc := NewRunCommand(mu)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 3000,
+		Alias:     true,
+	}
+
+	rc := NewRunCommand(mu, config)
 
 	args := []string{}
 
@@ -65,7 +86,14 @@ func TestRunNoPackage(t *testing.T) {
 func TestRunNonExistPackage(t *testing.T) {
 	mu := utils.NewMockUtility()
 
-	rc := NewRunCommand(mu)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 3000,
+		Alias:     true,
+	}
+
+	rc := NewRunCommand(mu, config)
 
 	args := []string{"nonexistent"}
 
@@ -90,8 +118,6 @@ func TestRunNonExistPackage(t *testing.T) {
 	//Set a variable with the proper call stack and see if the call stack matches
 	callStack := []string{
 		"GetHCLBody",
-		"GetHCLBody",
-		"ParseBody",
 		"ParseBody",
 	}
 
@@ -106,7 +132,14 @@ func TestRunImageNotExist(t *testing.T) {
 
 	mu.ImgExist = false
 
-	rc := NewRunCommand(mu)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 3000,
+		Alias:     true,
+	}
+
+	rc := NewRunCommand(mu, config)
 
 	args := []string{"python"}
 
@@ -131,8 +164,6 @@ func TestRunImageNotExist(t *testing.T) {
 	//Set a variable with the proper call stack and see if the call stack matches
 	callStack := []string{
 		"GetHCLBody",
-		"GetHCLBody",
-		"ParseBody",
 		"ParseBody",
 		"ImageExists",
 	}
@@ -157,7 +188,14 @@ func TestRunFlowNoRunArgs(t *testing.T) {
 
 	ed := filepath.Dir(ex)
 
-	rc := NewRunCommand(mu)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 3000,
+		Alias:     true,
+	}
+
+	rc := NewRunCommand(mu, config)
 
 	args := []string{"python"}
 
@@ -176,8 +214,6 @@ func TestRunFlowNoRunArgs(t *testing.T) {
 	//Set a variable with the proper call stack and see if the call stack matches
 	callStack := []string{
 		"GetHCLBody",
-		"GetHCLBody",
-		"ParseBody",
 		"ParseBody",
 		"ImageExists",
 		"RunContainer",
@@ -227,7 +263,14 @@ func TestRunFlowRunArgs(t *testing.T) {
 
 	ed := filepath.Dir(ex)
 
-	rc := NewRunCommand(mu)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 3000,
+		Alias:     true,
+	}
+
+	rc := NewRunCommand(mu, config)
 
 	args := []string{"python"}
 
@@ -250,8 +293,6 @@ func TestRunFlowRunArgs(t *testing.T) {
 	//Set a variable with the proper call stack and see if the call stack matches
 	callStack := []string{
 		"GetHCLBody",
-		"GetHCLBody",
-		"ParseBody",
 		"ParseBody",
 		"ImageExists",
 		"RunContainer",
@@ -294,7 +335,14 @@ func TestRunErrorAtGetHCLBody(t *testing.T) {
 
 	mu.ErrorAt = "GetHCLBody"
 
-	rc := NewRunCommand(mu)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 3000,
+		Alias:     true,
+	}
+
+	rc := NewRunCommand(mu, config)
 
 	args := []string{"python"}
 
@@ -333,7 +381,14 @@ func TestRunErrorAtParseBody(t *testing.T) {
 
 	mu.ErrorAt = "ParseBody"
 
-	rc := NewRunCommand(mu)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 3000,
+		Alias:     true,
+	}
+
+	rc := NewRunCommand(mu, config)
 
 	args := []string{"python"}
 
@@ -355,7 +410,6 @@ func TestRunErrorAtParseBody(t *testing.T) {
 
 	//Set a variable with the proper call stack and see if the call stack matches
 	callStack := []string{
-		"GetHCLBody",
 		"GetHCLBody",
 		"ParseBody",
 	}
@@ -373,7 +427,14 @@ func TestRunErrorAtImageExists(t *testing.T) {
 
 	mu.ErrorAt = "ImageExists"
 
-	rc := NewRunCommand(mu)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 3000,
+		Alias:     true,
+	}
+
+	rc := NewRunCommand(mu, config)
 
 	args := []string{"python"}
 
@@ -396,8 +457,6 @@ func TestRunErrorAtImageExists(t *testing.T) {
 	//Set a variable with the proper call stack and see if the call stack matches
 	callStack := []string{
 		"GetHCLBody",
-		"GetHCLBody",
-		"ParseBody",
 		"ParseBody",
 		"ImageExists",
 	}
@@ -415,7 +474,14 @@ func TestRunErrorAtRunContainer(t *testing.T) {
 
 	mu.ErrorAt = "RunContainer"
 
-	rc := NewRunCommand(mu)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 3000,
+		Alias:     true,
+	}
+
+	rc := NewRunCommand(mu, config)
 
 	args := []string{"python"}
 
@@ -438,8 +504,6 @@ func TestRunErrorAtRunContainer(t *testing.T) {
 	//Set a variable with the proper call stack and see if the call stack matches
 	callStack := []string{
 		"GetHCLBody",
-		"GetHCLBody",
-		"ParseBody",
 		"ParseBody",
 		"ImageExists",
 		"RunContainer",

--- a/subcommands/uninstall_sc.go
+++ b/subcommands/uninstall_sc.go
@@ -21,14 +21,17 @@ type UninstallCommand struct {
 	name string
 
 	tools utils.Tools
+
+	config utils.Config
 }
 
 //Instantiation method for a new UninstallCommand
-func NewUninstallCommand(tools utils.Tools) *UninstallCommand {
+func NewUninstallCommand(tools utils.Tools, config utils.Config) *UninstallCommand {
 	//Create a new UninstallCommand and set the FlagSet
 	uc := &UninstallCommand{
-		fs:    flag.NewFlagSet("uninstall", flag.ContinueOnError),
-		tools: tools,
+		fs:     flag.NewFlagSet("uninstall", flag.ContinueOnError),
+		tools:  tools,
+		config: config,
 	}
 
 	return uc
@@ -146,6 +149,8 @@ func (uc *UninstallCommand) Run() error {
 		return err
 	}
 
+	fmt.Println("Removing Image")
+
 	//Remove the image
 	err = uc.tools.RemoveImage(pack.Image, cli)
 
@@ -154,15 +159,19 @@ func (uc *UninstallCommand) Run() error {
 		return err
 	}
 
-	//Remove aliases
-	if runtime.GOOS == "windows" {
-		err = uc.tools.RemoveAliasWin(pack.Name, ed)
-	} else {
-		err = uc.tools.RemoveAliasUnix(pack.Name, ed)
-	}
+	if uc.config.Alias {
+		//Remove aliases
+		fmt.Println("Removing Alias")
 
-	if err != nil {
-		return err
+		if runtime.GOOS == "windows" {
+			err = uc.tools.RemoveAliasWin(pack.Name, ed)
+		} else {
+			err = uc.tools.RemoveAliasUnix(pack.Name, ed)
+		}
+
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/subcommands/uninstall_sc_test.go
+++ b/subcommands/uninstall_sc_test.go
@@ -13,7 +13,14 @@ import (
 func TestUninstallName(t *testing.T) {
 	mu := utils.NewMockUtility()
 
-	uc := NewUninstallCommand(mu)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     true,
+	}
+
+	uc := NewUninstallCommand(mu, config)
 
 	if uc.Name() != "uninstall" {
 		t.Fatal("The uninstall subcommand's name should be: uninstall | Subcommand Name: " + uc.Name())
@@ -24,7 +31,14 @@ func TestUninstallName(t *testing.T) {
 func TestUninstallInit(t *testing.T) {
 	mu := utils.NewMockUtility()
 
-	uc := NewUninstallCommand(mu)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     true,
+	}
+
+	uc := NewUninstallCommand(mu, config)
 
 	args := []string{"python"}
 
@@ -45,7 +59,14 @@ func TestUninstallNoPackage(t *testing.T) {
 
 	expectedErr := "No package name was found. You must include the name of the package you wish to uninstall."
 
-	uc := NewUninstallCommand(mu)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     true,
+	}
+
+	uc := NewUninstallCommand(mu, config)
 
 	args := []string{}
 
@@ -64,7 +85,14 @@ func TestUninstallNoPackage(t *testing.T) {
 func TestUninstallNonExistPackage(t *testing.T) {
 	mu := utils.NewMockUtility()
 
-	uc := NewUninstallCommand(mu)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     true,
+	}
+
+	uc := NewUninstallCommand(mu, config)
 
 	args := []string{"nonexistent"}
 
@@ -103,7 +131,14 @@ func TestUninstallImageNotExist(t *testing.T) {
 
 	mu.ImgExist = false
 
-	uc := NewUninstallCommand(mu)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     true,
+	}
+
+	uc := NewUninstallCommand(mu, config)
 
 	args := []string{"python"}
 
@@ -152,7 +187,14 @@ func TestUninstallFlow(t *testing.T) {
 
 	ed := filepath.Dir(ex)
 
-	uc := NewUninstallCommand(mu)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     true,
+	}
+
+	uc := NewUninstallCommand(mu, config)
 
 	args := []string{"python"}
 
@@ -230,7 +272,14 @@ func TestUninstallErrorAtGetHCLBody(t *testing.T) {
 
 	mu.ErrorAt = "GetHCLBody"
 
-	uc := NewUninstallCommand(mu)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     true,
+	}
+
+	uc := NewUninstallCommand(mu, config)
 
 	args := []string{"python"}
 
@@ -269,7 +318,14 @@ func TestUninstallErrorAtParseBody(t *testing.T) {
 
 	mu.ErrorAt = "ParseBody"
 
-	uc := NewUninstallCommand(mu)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     false,
+	}
+
+	uc := NewUninstallCommand(mu, config)
 
 	args := []string{"python"}
 
@@ -308,7 +364,14 @@ func TestUninstallErrorAtImageExists(t *testing.T) {
 
 	mu.ErrorAt = "ImageExists"
 
-	uc := NewUninstallCommand(mu)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     true,
+	}
+
+	uc := NewUninstallCommand(mu, config)
 
 	args := []string{"python"}
 
@@ -348,7 +411,14 @@ func TestUninstallErrorAtRemoveDir(t *testing.T) {
 
 	mu.ErrorAt = "RemoveDir"
 
-	uc := NewUninstallCommand(mu)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     true,
+	}
+
+	uc := NewUninstallCommand(mu, config)
 
 	args := []string{"python"}
 
@@ -389,7 +459,14 @@ func TestUninstallErrorAtRemoveAlias(t *testing.T) {
 
 	mu.ErrorAt = "RemoveAlias"
 
-	uc := NewUninstallCommand(mu)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     true,
+	}
+
+	uc := NewUninstallCommand(mu, config)
 
 	args := []string{"python"}
 
@@ -433,7 +510,14 @@ func TestUninstallErrorAtRemoveImage(t *testing.T) {
 
 	mu.ErrorAt = "RemoveImage"
 
-	uc := NewUninstallCommand(mu)
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     true,
+	}
+
+	uc := NewUninstallCommand(mu, config)
 
 	args := []string{"python"}
 
@@ -465,5 +549,87 @@ func TestUninstallErrorAtRemoveImage(t *testing.T) {
 
 	if !reflect.DeepEqual(callStack, mu.Calls) {
 		t.Fatalf("Call Stack does not match the expected call stack. Call Stack: %v | Expected Call Stack: %v", mu.Calls, callStack)
+	}
+}
+
+//Test uninstall when config Alias attribute is set to false
+func TestUninstallAliasFalse(t *testing.T) {
+	mu := utils.NewMockUtility()
+
+	mu.ImgExist = true
+
+	//Get the executable directory
+	ex, err := os.Executable()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ed := filepath.Dir(ex)
+
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     false,
+	}
+
+	uc := NewUninstallCommand(mu, config)
+
+	args := []string{"python"}
+
+	err = uc.Init(args)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = uc.Run()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//Set a variable with the proper call stack and see if the call stack matches
+	callStack := []string{
+		"GetHCLBody",
+		"ParseBody",
+		"ImageExists",
+		"RemoveDir",
+		"RemoveDir",
+		"RemoveImage",
+	}
+
+	//If the call stack doesn't match the test fails
+	if !reflect.DeepEqual(callStack, mu.Calls) {
+		t.Fatalf("Call Stack does not match the expected call stack. Call Stack: %v | Expected Call Stack: %v", mu.Calls, callStack)
+	}
+
+	//Make a list of images that should have been removed and make sure it matches from the MockUtility
+	var images []string
+
+	//directories to be removed
+	var rmdirs []string
+
+	//Fill lists
+	for _, pack := range mu.Pack.Packages {
+		images = append(images, pack.Image)
+
+		//Loop through volumes in the package
+		for _, vol := range pack.Volumes {
+			rmdirs = append(rmdirs, ed+vol.Path)
+		}
+
+		rmdirs = append(rmdirs, ed+pack.BaseDir)
+	}
+
+	//If the pulled images doesn't match the test fails
+	if !reflect.DeepEqual(images, mu.RemovedImgs) {
+		t.Fatalf("Removed Images does not match the expected Removed Images. Removed Images: %v | Expected Removed Images: %v", mu.RemovedImgs, images)
+	}
+
+	//If the directories made don't match, the test fails
+	if !reflect.DeepEqual(rmdirs, mu.RemovedDirs) {
+		t.Fatalf("Removed directories does not match the expected directories. Removed Directories: %v | Expected Removed Directories: %v", mu.RemovedDirs, rmdirs)
 	}
 }

--- a/testing/test_config.hcl
+++ b/testing/test_config.hcl
@@ -1,3 +1,4 @@
 base_dir="./test"
 start_port=5000
 port_increment=100
+alias=true

--- a/utils/hcl_parse.go
+++ b/utils/hcl_parse.go
@@ -40,6 +40,7 @@ type Config struct {
 	BaseDir   string `hcl:"base_dir,attr"`
 	StartPort int    `hcl:"start_port,attr"`
 	PortInc   int    `hcl:"port_increment,attr"`
+	Alias     bool   `hcl:"alias,attr"`
 }
 
 //Parse function to parse the HCL body given

--- a/utils/hcl_parse_test.go
+++ b/utils/hcl_parse_test.go
@@ -15,7 +15,8 @@ func TestParseBodyConfig(t *testing.T) {
 	//Create the HCL byte array
 	hcl := []byte(`base_dir="./"
 	start_port=3000
-	port_increment=1`)
+	port_increment=1
+	alias=true`)
 
 	//Create the parser
 	parser := hclparse.NewParser()
@@ -53,6 +54,10 @@ func TestParseBodyConfig(t *testing.T) {
 
 	if config.StartPort != 3000 {
 		t.Fatal("Config Start Port should be '3000' | Received: " + strconv.Itoa(config.StartPort))
+	}
+
+	if !config.Alias {
+		t.Fatal("Config attribute 'alias' should be set to true. Instead it was set to false.")
 	}
 }
 
@@ -281,6 +286,7 @@ func TestHCLParse_Integration_Config(t *testing.T) {
 	cBD := "./test"
 	cSP := 5000
 	cPI := 100
+	cA := true
 
 	//Ensure the base dir is correct
 	if config.BaseDir != cBD {
@@ -295,6 +301,10 @@ func TestHCLParse_Integration_Config(t *testing.T) {
 	//Ensure the port increment is correct
 	if config.PortInc != cPI {
 		t.Fatalf("HCL Parse Integration: Expected PortInc: %d | Received: %d", cPI, config.PortInc)
+	}
+
+	if config.Alias != cA {
+		t.Fatalf("HCL Parse Integration: Expected Alias: %s | Received: %s", strconv.FormatBool(cA), strconv.FormatBool(config.Alias))
 	}
 
 }


### PR DESCRIPTION
Implements in the configuration file an option to set automated alias setting to a value of **true** or **false**. This feature was defined in issue #18 