### PR TITLE
Feature/package versioning

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -122,7 +122,7 @@ func TestMain_OsArgs(t *testing.T) {
 			exit, err := wrappedMain()
 
 			if (exit != 0) != tc.Err {
-				t.Fatalf("Fail - Exit code did not match the expected")
+				t.Fatalf("Fail - Exit code did not match the expected | Received Error: %s", err)
 			} else {
 				if tc.ExpectedErr != "" {
 					if err.Error() != tc.ExpectedErr {

--- a/package_list.hcl
+++ b/package_list.hcl
@@ -1,20 +1,24 @@
 package "python" {
-    image="packageless/python"
     base_dir="/python/"
+   
+    version "latest" {
+        image="packageless/python"
+        
+        volume {
+            path="/python/packages/"
+            mount="/usr/local/lib/python3.9/site-packages/"
+        }
+
+        volume {
+            mount="/run/"
+        }
+
+        copy {
+            source="/usr/local/lib/python3.9/site-packages/"
+            dest="/python/packages/"
+        }
+
+        port="3000"
+    }
     
-    volume {
-        path="/python/packages/"
-        mount="/usr/local/lib/python3.9/site-packages/"
-    }
-
-    volume {
-        mount="/run/"
-    }
-
-    copy {
-        source="/usr/local/lib/python3.9/site-packages/"
-        dest="/python/packages/"
-    }
-
-    port="3000"
 }

--- a/subcommands/install_sc.go
+++ b/subcommands/install_sc.go
@@ -143,7 +143,7 @@ func (ic *InstallCommand) Run() error {
 		return errors.New("Package " + pack.Name + " is already installed")
 	}
 
-	fmt.Println("Installing", pack.Name)
+	fmt.Println("Installing", pack.Name+":"+version.Version)
 	//Pull the image down from Docker Hub
 	err = ic.tools.PullImage(version.Image, cli)
 

--- a/subcommands/install_sc.go
+++ b/subcommands/install_sc.go
@@ -208,9 +208,17 @@ func (ic *InstallCommand) Run() error {
 		fmt.Println("Setting Alias")
 
 		if runtime.GOOS == "windows" {
-			err = ic.tools.AddAliasWin(pack.Name, ed)
+			if version.Version != "latest" {
+				err = ic.tools.AddAliasWin(pack.Name+":"+version.Version, ed)
+			} else {
+				err = ic.tools.AddAliasWin(pack.Name, ed)
+			}
 		} else {
-			err = ic.tools.AddAliasUnix(pack.Name, ed)
+			if version.Version != "latest" {
+				err = ic.tools.AddAliasUnix(pack.Name+":"+version.Version, ed)
+			} else {
+				err = ic.tools.AddAliasUnix(pack.Name, ed)
+			}
 		}
 
 		if err != nil {

--- a/subcommands/run_sc.go
+++ b/subcommands/run_sc.go
@@ -140,7 +140,7 @@ func (rc *RunCommand) Run() error {
 
 	//If the image exists the package is already installed
 	if !imgExist {
-		return errors.New("Package " + pack.Name + " is not installed. You must install the package before running it.")
+		return errors.New("Package " + pack.Name + " with version '" + version.Version + "' is not installed. You must install the package before running it.")
 	}
 
 	//Create the variables to use when running the container

--- a/subcommands/run_sc.go
+++ b/subcommands/run_sc.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/docker/docker/client"
 	"github.com/everettraven/packageless/utils"
@@ -62,6 +63,19 @@ func (rc *RunCommand) Run() error {
 	//Create variables to use later
 	var found bool
 	var pack utils.Package
+	var version utils.Version
+
+	var packName string
+	var packVersion string
+
+	if strings.Contains(rc.name, ":") {
+		split := strings.Split(rc.name, ":")
+		packName = split[0]
+		packVersion = split[1]
+	} else {
+		packName = rc.name
+		packVersion = "latest"
+	}
 
 	//Create the Docker client
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
@@ -98,20 +112,26 @@ func (rc *RunCommand) Run() error {
 	//Look for the package we want in the package list
 	for _, packs := range packages.Packages {
 		//If we find it, set some variables and break
-		if packs.Name == rc.name {
-			found = true
+		if packs.Name == packName {
 			pack = packs
-			break
+
+			for _, ver := range pack.Versions {
+				if ver.Version == packVersion {
+					found = true
+					version = ver
+					break
+				}
+			}
 		}
 	}
 
 	//Make sure we have found the package in the package list
 	if !found {
-		return errors.New("Could not find package " + rc.name + " in the package list")
+		return errors.New("Could not find package " + packName + " with version '" + packVersion + "' in the package list")
 	}
 
 	//Check if the corresponding package image is already installed
-	imgExist, err := rc.tools.ImageExists(pack.Image, cli)
+	imgExist, err := rc.tools.ImageExists(version.Image, cli)
 
 	//Check for errors
 	if err != nil {
@@ -127,9 +147,9 @@ func (rc *RunCommand) Run() error {
 	var ports []string
 	var volumes []string
 
-	ports = append(ports, strconv.Itoa(rc.config.StartPort)+":"+pack.Port)
+	ports = append(ports, strconv.Itoa(rc.config.StartPort)+":"+version.Port)
 
-	for _, vol := range pack.Volumes {
+	for _, vol := range version.Volumes {
 		if vol.Path != "" {
 			volumes = append(volumes, ed+vol.Path+":"+vol.Mount)
 		} else {
@@ -144,7 +164,7 @@ func (rc *RunCommand) Run() error {
 	}
 
 	//Run the container
-	_, err = rc.tools.RunContainer(pack.Image, ports, volumes, pack.Name, rc.args)
+	_, err = rc.tools.RunContainer(version.Image, ports, volumes, pack.Name, rc.args)
 
 	if err != nil {
 		return err

--- a/subcommands/run_sc_test.go
+++ b/subcommands/run_sc_test.go
@@ -143,7 +143,7 @@ func TestRunImageNotExist(t *testing.T) {
 
 	args := []string{"python"}
 
-	expectedErr := "Package python is not installed. You must install the package before running it."
+	expectedErr := "Package python with version 'latest' is not installed. You must install the package before running it."
 
 	err := rc.Init(args)
 

--- a/subcommands/run_sc_test.go
+++ b/subcommands/run_sc_test.go
@@ -97,7 +97,7 @@ func TestRunNonExistPackage(t *testing.T) {
 
 	args := []string{"nonexistent"}
 
-	expectedErr := "Could not find package nonexistent in the package list"
+	expectedErr := "Could not find package nonexistent with version 'latest' in the package list"
 
 	err := rc.Init(args)
 
@@ -225,12 +225,12 @@ func TestRunFlowNoRunArgs(t *testing.T) {
 	}
 
 	//Make sure the image that was ran matches the package image
-	if mu.RunImage != mu.Pack.Packages[0].Image {
-		t.Fatalf("RunContainer: Image does not match the expected Image. Received Image: %s | Expected Image: %s", mu.RunImage, mu.Pack.Packages[0].Image)
+	if mu.RunImage != mu.Pack.Packages[0].Versions[0].Image {
+		t.Fatalf("RunContainer: Image does not match the expected Image. Received Image: %s | Expected Image: %s", mu.RunImage, mu.Pack.Packages[0].Versions[0].Image)
 	}
 
-	port := []string{strconv.Itoa(mu.Conf.StartPort) + ":" + mu.Pack.Packages[0].Port}
-	volume := []string{ed + mu.Pack.Packages[0].Volumes[0].Path + ":" + mu.Pack.Packages[0].Volumes[0].Mount}
+	port := []string{strconv.Itoa(mu.Conf.StartPort) + ":" + mu.Pack.Packages[0].Versions[0].Port}
+	volume := []string{ed + mu.Pack.Packages[0].Versions[0].Volumes[0].Path + ":" + mu.Pack.Packages[0].Versions[0].Volumes[0].Mount}
 
 	//Make sure the ports passed in matches
 	if !reflect.DeepEqual(mu.RunPorts, port) {
@@ -304,12 +304,12 @@ func TestRunFlowRunArgs(t *testing.T) {
 	}
 
 	//Make sure the image that was ran matches the package image
-	if mu.RunImage != mu.Pack.Packages[0].Image {
-		t.Fatalf("RunContainer: Image does not match the expected Image. Received Image: %s | Expected Image: %s", mu.RunImage, mu.Pack.Packages[0].Image)
+	if mu.RunImage != mu.Pack.Packages[0].Versions[0].Image {
+		t.Fatalf("RunContainer: Image does not match the expected Image. Received Image: %s | Expected Image: %s", mu.RunImage, mu.Pack.Packages[0].Versions[0].Image)
 	}
 
-	port := []string{strconv.Itoa(mu.Conf.StartPort) + ":" + mu.Pack.Packages[0].Port}
-	volume := []string{ed + mu.Pack.Packages[0].Volumes[0].Path + ":" + mu.Pack.Packages[0].Volumes[0].Mount}
+	port := []string{strconv.Itoa(mu.Conf.StartPort) + ":" + mu.Pack.Packages[0].Versions[0].Port}
+	volume := []string{ed + mu.Pack.Packages[0].Versions[0].Volumes[0].Path + ":" + mu.Pack.Packages[0].Versions[0].Volumes[0].Mount}
 
 	//Make sure the ports passed in matches
 	if !reflect.DeepEqual(mu.RunPorts, port) {
@@ -507,6 +507,50 @@ func TestRunErrorAtRunContainer(t *testing.T) {
 		"ParseBody",
 		"ImageExists",
 		"RunContainer",
+	}
+
+	if !reflect.DeepEqual(callStack, mu.Calls) {
+		t.Fatalf("Call Stack does not match the expected call stack. Call Stack: %v | Expected Call Stack: %v", mu.Calls, callStack)
+	}
+}
+
+//Test the Run subcommand with a package with a nonexistent version specified
+func TestRunNonExistVersion(t *testing.T) {
+	mu := utils.NewMockUtility()
+
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 3000,
+		Alias:     true,
+	}
+
+	rc := NewRunCommand(mu, config)
+
+	args := []string{"python:idontexist"}
+
+	expectedErr := "Could not find package python with version 'idontexist' in the package list"
+
+	err := rc.Init(args)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = rc.Run()
+
+	if err == nil {
+		t.Fatal("Expected the following error: '" + expectedErr + "' but did not receive an error")
+	}
+
+	if err.Error() != expectedErr {
+		t.Fatal("Expected the following error: " + expectedErr + "| Received: " + err.Error())
+	}
+
+	//Set a variable with the proper call stack and see if the call stack matches
+	callStack := []string{
+		"GetHCLBody",
+		"ParseBody",
 	}
 
 	if !reflect.DeepEqual(callStack, mu.Calls) {

--- a/subcommands/uninstall_sc.go
+++ b/subcommands/uninstall_sc.go
@@ -184,9 +184,17 @@ func (uc *UninstallCommand) Run() error {
 		fmt.Println("Removing Alias")
 
 		if runtime.GOOS == "windows" {
-			err = uc.tools.RemoveAliasWin(pack.Name, ed)
+			if version.Version != "latest" {
+				err = uc.tools.RemoveAliasWin(pack.Name+":"+version.Version, ed)
+			} else {
+				err = uc.tools.RemoveAliasWin(pack.Name, ed)
+			}
 		} else {
-			err = uc.tools.RemoveAliasUnix(pack.Name, ed)
+			if version.Version != "latest" {
+				err = uc.tools.RemoveAliasUnix(pack.Name+":"+version.Version, ed)
+			} else {
+				err = uc.tools.RemoveAliasUnix(pack.Name, ed)
+			}
 		}
 
 		if err != nil {

--- a/subcommands/uninstall_sc.go
+++ b/subcommands/uninstall_sc.go
@@ -142,10 +142,10 @@ func (uc *UninstallCommand) Run() error {
 
 	//If the image doesn't exist it can't be uninstalled
 	if !imgExist {
-		return errors.New("Package " + pack.Name + " is not installed.")
+		return errors.New("Package " + pack.Name + " with version '" + version.Version + "' is not installed.")
 	}
 
-	fmt.Println("Removing package", pack.Name)
+	fmt.Println("Removing", pack.Name+":"+version.Version)
 
 	//Check for the directories that correspond to this packages volumes
 	fmt.Println("Removing package directories")

--- a/subcommands/uninstall_sc_test.go
+++ b/subcommands/uninstall_sc_test.go
@@ -142,7 +142,7 @@ func TestUninstallImageNotExist(t *testing.T) {
 
 	args := []string{"python"}
 
-	expectedErr := "Package python is not installed."
+	expectedErr := "Package python with version 'latest' is not installed."
 
 	err := uc.Init(args)
 

--- a/subcommands/uninstall_sc_test.go
+++ b/subcommands/uninstall_sc_test.go
@@ -96,7 +96,7 @@ func TestUninstallNonExistPackage(t *testing.T) {
 
 	args := []string{"nonexistent"}
 
-	expectedErr := "Could not find package nonexistent in the package list"
+	expectedErr := "Could not find package nonexistent with version 'latest' in the package list"
 
 	err := uc.Init(args)
 
@@ -237,15 +237,19 @@ func TestUninstallFlow(t *testing.T) {
 
 	//Fill lists
 	for _, pack := range mu.Pack.Packages {
-		images = append(images, pack.Image)
+		//Just use the first version
+		version := pack.Versions[0]
+		images = append(images, version.Image)
 		aliasCmds = append(aliasCmds, pack.Name)
 
 		//Loop through volumes in the package
-		for _, vol := range pack.Volumes {
+		for _, vol := range version.Volumes {
 			rmdirs = append(rmdirs, ed+vol.Path)
 		}
 
 		rmdirs = append(rmdirs, ed+pack.BaseDir)
+		//Just use the first package for the test
+		break
 	}
 
 	//If the pulled images doesn't match the test fails
@@ -613,14 +617,19 @@ func TestUninstallAliasFalse(t *testing.T) {
 
 	//Fill lists
 	for _, pack := range mu.Pack.Packages {
-		images = append(images, pack.Image)
+		//Just use the first version
+		version := pack.Versions[0]
+		images = append(images, version.Image)
 
 		//Loop through volumes in the package
-		for _, vol := range pack.Volumes {
+		for _, vol := range version.Volumes {
 			rmdirs = append(rmdirs, ed+vol.Path)
 		}
 
 		rmdirs = append(rmdirs, ed+pack.BaseDir)
+
+		//Just use the first package
+		break
 	}
 
 	//If the pulled images doesn't match the test fails
@@ -631,5 +640,49 @@ func TestUninstallAliasFalse(t *testing.T) {
 	//If the directories made don't match, the test fails
 	if !reflect.DeepEqual(rmdirs, mu.RemovedDirs) {
 		t.Fatalf("Removed directories does not match the expected directories. Removed Directories: %v | Expected Removed Directories: %v", mu.RemovedDirs, rmdirs)
+	}
+}
+
+//Test the uninstall subcommand with a package with a nonexistent version specified
+func TestUninstallNonExistVersion(t *testing.T) {
+	mu := utils.NewMockUtility()
+
+	config := utils.Config{
+		BaseDir:   "./",
+		PortInc:   1,
+		StartPort: 5000,
+		Alias:     true,
+	}
+
+	uc := NewUninstallCommand(mu, config)
+
+	args := []string{"python:idontexist"}
+
+	expectedErr := "Could not find package python with version 'idontexist' in the package list"
+
+	err := uc.Init(args)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = uc.Run()
+
+	if err == nil {
+		t.Fatal("Expected the following error: '" + expectedErr + "' but did not receive an error")
+	}
+
+	if err.Error() != expectedErr {
+		t.Fatal("Expected the following error: " + expectedErr + "| Received: " + err.Error())
+	}
+
+	//Set a variable with the proper call stack and see if the call stack matches
+	callStack := []string{
+		"GetHCLBody",
+		"ParseBody",
+	}
+
+	if !reflect.DeepEqual(callStack, mu.Calls) {
+		t.Fatalf("Call Stack does not match the expected call stack. Call Stack: %v | Expected Call Stack: %v", mu.Calls, callStack)
 	}
 }

--- a/subcommands/upgrade_sc.go
+++ b/subcommands/upgrade_sc.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/docker/docker/client"
 	"github.com/everettraven/packageless/utils"
@@ -56,6 +57,19 @@ func (ic *UpgradeCommand) Run() error {
 	//Create variables to use later
 	var found bool
 	var pack utils.Package
+	var version utils.Version
+
+	var packName string
+	var packVersion string
+
+	if strings.Contains(ic.name, ":") {
+		split := strings.Split(ic.name, ":")
+		packName = split[0]
+		packVersion = split[1]
+	} else {
+		packName = ic.name
+		packVersion = "latest"
+	}
 
 	//Create the Docker client
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
@@ -93,20 +107,26 @@ func (ic *UpgradeCommand) Run() error {
 		//Look for the package we want in the package list
 		for _, packs := range packages.Packages {
 			//If we find it, set some variables and break
-			if packs.Name == ic.name {
-				found = true
+			if packs.Name == packName {
 				pack = packs
-				break
+
+				for _, ver := range pack.Versions {
+					if ver.Version == packVersion {
+						found = true
+						version = ver
+						break
+					}
+				}
 			}
 		}
 
 		//Make sure we have found the package in the package list
 		if !found {
-			return errors.New("Could not find package " + ic.name + " in the package list")
+			return errors.New("Could not find package " + packName + " with version '" + packVersion + "' in the package list")
 		}
 
 		//Check if the corresponding package image is already installed
-		imgExist, err := ic.tools.ImageExists(pack.Image, cli)
+		imgExist, err := ic.tools.ImageExists(version.Image, cli)
 
 		//Check for errors
 		if err != nil {
@@ -120,7 +140,7 @@ func (ic *UpgradeCommand) Run() error {
 
 		fmt.Println("Upgrading", pack.Name)
 		//Pull the image down from Docker Hub
-		err = ic.tools.PullImage(pack.Image, cli)
+		err = ic.tools.PullImage(version.Image, cli)
 
 		if err != nil {
 			return err
@@ -129,7 +149,7 @@ func (ic *UpgradeCommand) Run() error {
 		fmt.Println("Updating package directories")
 
 		//Check the volumes and create the directories for them if they don't already exist
-		for _, vol := range pack.Volumes {
+		for _, vol := range version.Volumes {
 			//Make sure that a path is given. If not we already assume that the working directory will be mounted
 			if vol.Path != "" {
 				err = ic.tools.UpgradeDir(ed + vol.Path)
@@ -141,11 +161,11 @@ func (ic *UpgradeCommand) Run() error {
 		}
 
 		//Check and see if any files need to be copied from the container to one of the volumes on the host.
-		if len(pack.Copies) > 0 {
+		if len(version.Copies) > 0 {
 
 			fmt.Println("Copying necessary files 1/3")
 			//Create the container so that we can copy the files over to the right places
-			containerID, err := ic.tools.CreateContainer(pack.Image, cli)
+			containerID, err := ic.tools.CreateContainer(version.Image, cli)
 
 			if err != nil {
 				return err
@@ -153,7 +173,7 @@ func (ic *UpgradeCommand) Run() error {
 
 			fmt.Println("Copying necessary files 2/3")
 			//Copy the files from the container to the locations
-			for _, copy := range pack.Copies {
+			for _, copy := range version.Copies {
 				err = ic.tools.CopyFromContainer(copy.Source, ed+copy.Dest, containerID, cli, ic.cp)
 
 				if err != nil {
@@ -175,75 +195,78 @@ func (ic *UpgradeCommand) Run() error {
 	} else {
 		//Loop through the packages in the package list
 		for _, pack := range packages.Packages {
-			//Check if the corresponding package image is already installed
-			imgExist, err := ic.tools.ImageExists(pack.Image, cli)
 
-			//Check for errors
-			if err != nil {
-				return err
-			}
+			for _, ver := range pack.Versions {
+				//Check if the corresponding package image is already installed
+				imgExist, err := ic.tools.ImageExists(ver.Image, cli)
 
-			//If the image exists the package is already installed
-			if !imgExist {
-				continue
-			}
-
-			fmt.Println("Upgrading", pack.Name)
-			//Pull the image down from Docker Hub
-			err = ic.tools.PullImage(pack.Image, cli)
-
-			if err != nil {
-				return err
-			}
-
-			fmt.Println("Updating package directories")
-
-			//Check the volumes and create the directories for them if they don't already exist
-			for _, vol := range pack.Volumes {
-				//Make sure that a path is given. If not we already assume that the working directory will be mounted
-				if vol.Path != "" {
-					err = ic.tools.UpgradeDir(ed + vol.Path)
-
-					if err != nil {
-						return err
-					}
+				//Check for errors
+				if err != nil {
+					return err
 				}
-			}
 
-			//Check and see if any files need to be copied from the container to one of the volumes on the host.
-			if len(pack.Copies) > 0 {
+				//If the image exists the package is already installed
+				if !imgExist {
+					continue
+				}
 
-				fmt.Println("Copying necessary files 1/3")
-				//Create the container so that we can copy the files over to the right places
-				containerID, err := ic.tools.CreateContainer(pack.Image, cli)
+				fmt.Println("Upgrading", pack.Name)
+				//Pull the image down from Docker Hub
+				err = ic.tools.PullImage(ver.Image, cli)
 
 				if err != nil {
 					return err
 				}
 
-				fmt.Println("Copying necessary files 2/3")
-				//Copy the files from the container to the locations
-				for _, copy := range pack.Copies {
-					err = ic.tools.CopyFromContainer(copy.Source, ed+copy.Dest, containerID, cli, ic.cp)
+				fmt.Println("Updating package directories")
+
+				//Check the volumes and create the directories for them if they don't already exist
+				for _, vol := range ver.Volumes {
+					//Make sure that a path is given. If not we already assume that the working directory will be mounted
+					if vol.Path != "" {
+						err = ic.tools.UpgradeDir(ed + vol.Path)
+
+						if err != nil {
+							return err
+						}
+					}
+				}
+
+				//Check and see if any files need to be copied from the container to one of the volumes on the host.
+				if len(ver.Copies) > 0 {
+
+					fmt.Println("Copying necessary files 1/3")
+					//Create the container so that we can copy the files over to the right places
+					containerID, err := ic.tools.CreateContainer(ver.Image, cli)
 
 					if err != nil {
 						return err
 					}
+
+					fmt.Println("Copying necessary files 2/3")
+					//Copy the files from the container to the locations
+					for _, copy := range ver.Copies {
+						err = ic.tools.CopyFromContainer(copy.Source, ed+copy.Dest, containerID, cli, ic.cp)
+
+						if err != nil {
+							return err
+						}
+					}
+
+					fmt.Println("Copying necessary files 3/3")
+					//Remove the Container
+					err = ic.tools.RemoveContainer(containerID, cli)
+
+					if err != nil {
+						return err
+					}
+
+					fmt.Println(pack.Name, "successfully upgraded")
 				}
 
-				fmt.Println("Copying necessary files 3/3")
-				//Remove the Container
-				err = ic.tools.RemoveContainer(containerID, cli)
-
-				if err != nil {
-					return err
-				}
-
-				fmt.Println(pack.Name, "successfully upgraded")
 			}
 
 		}
-
 	}
 
 	return nil

--- a/subcommands/upgrade_sc.go
+++ b/subcommands/upgrade_sc.go
@@ -135,10 +135,10 @@ func (ic *UpgradeCommand) Run() error {
 
 		//If the image exists the package is already installed
 		if !imgExist {
-			return errors.New("Package: " + pack.Name + " is not installed. It must be installed before it can be upgraded.")
+			return errors.New("Package: " + pack.Name + " with version '" + version.Version + "' is not installed. It must be installed before it can be upgraded.")
 		}
 
-		fmt.Println("Upgrading", pack.Name)
+		fmt.Println("Upgrading", pack.Name+":"+version.Version)
 		//Pull the image down from Docker Hub
 		err = ic.tools.PullImage(version.Image, cli)
 
@@ -210,7 +210,7 @@ func (ic *UpgradeCommand) Run() error {
 					continue
 				}
 
-				fmt.Println("Upgrading", pack.Name)
+				fmt.Println("Upgrading", pack.Name+":"+ver.Version)
 				//Pull the image down from Docker Hub
 				err = ic.tools.PullImage(ver.Image, cli)
 

--- a/subcommands/upgrade_sc_test.go
+++ b/subcommands/upgrade_sc_test.go
@@ -522,7 +522,7 @@ func TestUpgradeImageNotExists(t *testing.T) {
 	mu.ImgExist = false
 
 	args := []string{"python"}
-	expectedErr := "Package: python is not installed. It must be installed before it can be upgraded."
+	expectedErr := "Package: python with version 'latest' is not installed. It must be installed before it can be upgraded."
 
 	mcp := &utils.MockCopyTool{}
 

--- a/testing/test_package_list.hcl
+++ b/testing/test_package_list.hcl
@@ -1,20 +1,24 @@
 package "test" {
-    image="packageless/testing"
     base_dir="/base"
+
+    version "latest" {
+        image="packageless/testing"
     
-    volume {
-        path="/a/path"
-        mount="/mount/path"
-    }
+        volume {
+            path="/a/path"
+            mount="/mount/path"
+        }
 
-    volume {
-        mount="/run/"
-    }
+        volume {
+            mount="/run/"
+        }
 
-    copy {
-        source="/a/source"
-        dest="/a/dest"
-    }
+        copy {
+            source="/a/source"
+            dest="/a/dest"
+        }
 
-    port="3000"
+        port="3000"
+    }
+    
 }

--- a/utils/hcl_parse.go
+++ b/utils/hcl_parse.go
@@ -22,9 +22,14 @@ type Volume struct {
 
 //Package object to parse the package block in the package list
 type Package struct {
-	Name    string   `hcl:"name,label"`
+	Name     string    `hcl:"name,label"`
+	BaseDir  string    `hcl:"base_dir,attr"`
+	Versions []Version `hcl:"version,block"`
+}
+
+type Version struct {
+	Version string   `hcl:"version,label"`
 	Image   string   `hcl:"image,attr"`
-	BaseDir string   `hcl:"base_dir,attr"`
 	Volumes []Volume `hcl:"volume,block"`
 	Copies  []*Copy  `hcl:"copy,block"`
 	Port    string   `hcl:"port,optional"`

--- a/utils/mocks.go
+++ b/utils/mocks.go
@@ -90,21 +90,27 @@ func NewMockUtility() *MockUtility {
 			Packages: []Package{
 				{
 					Name:    "python",
-					Image:   "packageless/python",
 					BaseDir: "/base",
-					Volumes: []Volume{
+					Versions: []Version{
 						{
-							Path:  "/a/path",
-							Mount: "/another/one",
+							Version: "latest",
+							Image:   "packageless/python",
+
+							Volumes: []Volume{
+								{
+									Path:  "/a/path",
+									Mount: "/another/one",
+								},
+							},
+							Copies: []*Copy{
+								{
+									Source: "/source/path",
+									Dest:   "/destination",
+								},
+							},
+							Port: "3000",
 						},
 					},
-					Copies: []*Copy{
-						{
-							Source: "/source/path",
-							Dest:   "/destination",
-						},
-					},
-					Port: "3000",
 				},
 			},
 		},


### PR DESCRIPTION
## Proposed Changes
Enable versions for packages to be defined within one package definition block in the package list. This will make it significantly easier to keep track of versions. Different versions of packages can be used in the commands as such:
```
package:version
```
To retrieve the latest version of a package, you do not need to specify the package version when running commands. It is assumed that if the version is not specified that you want the latest version.

You may also use `package:latest` to get the latest version of the package

Aliases will also be set in a similar format. 

For example:

If you install the latest version of Python, the alias will be `python` but if you install Python 3.7 the alias would be `python:3.7`

## Type of Change
What kind of change to **packageless** is this?

- [ ] Bug Fix
- [x] Feature
- [ ] Documentation
- [ ] Repository Enhancement
- [ ] Testing

## Checklist
Before the Pull Request can be considered for merging, the following Checklist should have the corresponding fields completed:

- [x] All tests have passed locally after running `go test ./...`
- [x] I have added tests that prove my fix or feature works as expected
- [ ] I have added any necessary documentation for my fix or feature

## Comments
Any further information you want to provide can go here.
