### PR TITLE
Feature/version subcommand

### DIFF
--- a/docs/docs/cli/subcommands/version.md
+++ b/docs/docs/cli/subcommands/version.md
@@ -1,0 +1,20 @@
+---
+id: subcommand-version
+title: version
+---
+
+## Usage
+```
+packageless version
+```
+
+This subcommand will output the version of packageless that is currently installed.
+
+## Examples
+```
+packageless version
+```
+Output:
+```
+Packageless Version: v0.0.0
+```

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -26,7 +26,8 @@ module.exports = {
               'cli/subcommands/subcommand-install',
               'cli/subcommands/subcommand-uninstall',
               'cli/subcommands/subcommand-run',
-              'cli/subcommands/subcommand-upgrade'
+              'cli/subcommands/subcommand-upgrade',
+              'cli/subcommands/subcommand-version'
             ]
           },
         ]

--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ func wrappedMain() (int, error) {
 		subcommands.NewUninstallCommand(util, config),
 		subcommands.NewUpgradeCommand(util, cp),
 		subcommands.NewRunCommand(util, config),
+		subcommands.NewVersionCommand(),
 	}
 
 	//Run the subcommands

--- a/subcommands/version_sc.go
+++ b/subcommands/version_sc.go
@@ -1,0 +1,40 @@
+package subcommands
+
+import (
+	"flag"
+	"fmt"
+)
+
+var version = "v0.0.0"
+
+type VersionCommand struct {
+	//FlagSet for the version command
+	fs *flag.FlagSet
+}
+
+//Instantiation method for a new VersionCommand
+func NewVersionCommand() *VersionCommand {
+	//Create a new InstallCommand and set the FlagSet
+	vc := &VersionCommand{
+		fs: flag.NewFlagSet("version", flag.ContinueOnError),
+	}
+
+	return vc
+}
+
+//Name - Gets the name of the Sub-Command
+func (vc *VersionCommand) Name() string {
+	return vc.fs.Name()
+}
+
+//Initialize the command, for this particular subcommand we should just do nothing
+func (vc *VersionCommand) Init(args []string) error {
+	return nil
+}
+
+//Run the command, this particular command should be a
+//simple print of the value of the version variable
+func (vc *VersionCommand) Run() error {
+	fmt.Println("Packageless Version: " + version)
+	return nil
+}

--- a/subcommands/version_sc_test.go
+++ b/subcommands/version_sc_test.go
@@ -1,0 +1,32 @@
+package subcommands
+
+import "testing"
+
+func TestVersionName(t *testing.T) {
+	expected := "version"
+	vc := NewVersionCommand()
+
+	if vc.Name() != expected {
+		t.Fatalf("The version subcommand's name should be: '%s' but was '%s'", expected, vc.Name())
+	}
+}
+
+func TestVersionInit(t *testing.T) {
+	vc := NewVersionCommand()
+
+	err := vc.Init([]string{})
+
+	if err != nil {
+		t.Fatalf("This method should do nothing except return nil | Received: %s", err)
+	}
+}
+
+func ExampleVersion() {
+	vc := NewVersionCommand()
+
+	vc.Run()
+
+	// Output:
+	// Packageless Version: v0.0.0
+
+}


### PR DESCRIPTION
## Proposed Changes
**packageless** should have a subcommand to output the version that is currently installed. This change implements that by adding a version subcommand that can be ran by running:
```
packageless version
```

## Type of Change
What kind of change to **packageless** is this?

- [ ] Bug Fix
- [x] Feature
- [ ] Documentation
- [ ] Repository Enhancement
- [ ] Testing

## Checklist
Before the Pull Request can be considered for merging, the following Checklist should have the corresponding fields completed:

- [x] All tests have passed locally after running `go test ./...`
- [x] I have added tests that prove my fix or feature works as expected
- [x] I have added any necessary documentation for my fix or feature

## Comments
Any further information you want to provide can go here.
