### PR TITLE
split windows build and unix builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,12 @@ on:
 
 # Set up the actual workflow jobs
 jobs:
-  # Build the executable on windows and upload it as an artifact to use in the release
-  build-executables:
+  # Build the executable on linux and mac and upload it as an artifact to use in the release
+  build-unix-executables:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     # Checkout the repo to build the file
     steps:
       - name: lowercase Runner OS
@@ -30,17 +30,35 @@ jobs:
         with:
           go-version: 1.16.4
       - name: Build ${{ runner.os }} packageless with tag as version
-        run: go build -ldflags "-X github.com/everettraven/packageless/subcommands.version=${{ github.ref }}" -o packageless-${{ env.RUNNER_OS_LOWER }}
+        run: go build -ldflags "-X github.com/everettraven/packageless/subcommands.version=${{ github.ref_name }}" -o packageless-${{ env.RUNNER_OS_LOWER }}
       - name: Upload build artifacts for ${{ runner.os }}
         uses: actions/upload-artifact@v2
         with:
           name: build-${{ env.RUNNER_OS_LOWER }}-${{ github.ref_name }}
           path: packageless-${{ env.RUNNER_OS_LOWER }}
+  # Build the executable on Windows, upload as artifact
+  build-windows-executable:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.4
+      - name: Build ${{ runner.os }} packageless with tag as version
+        run: go build -ldflags "-X github.com/everettraven/packageless/subcommands.version=${{ github.ref_name }}" -o packageless-windows
+      - name: Upload build artifacts for ${{ runner.os }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-windows-${{ github.ref_name }}
+          path: packageless-windows
+
   # Create the release and upload the executable files
   release:
-    needs: build-executables
+    needs: [build-unix-executables, build-windows-executable]
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
       - name: Download Windows build artifact
         uses: actions/download-artifact@v2
         with:
@@ -61,5 +79,6 @@ jobs:
             packageless-windows
             packageless-linux
             packageless-macos
+            config.hcl
           generate_release_notes: true
       


### PR DESCRIPTION
## Proposed Changes
fix the release workflow for packageless. This change splits the windows build and unix-based builds into separate jobs. Also add the config.hcl file as an upload to the release.

## Type of Change
What kind of change to **packageless** is this?

- [x] Bug Fix
- [ ] Feature
- [ ] Documentation
- [ ] Repository Enhancement
- [ ] Testing

## Checklist
Before the Pull Request can be considered for merging, the following Checklist should have the corresponding fields completed:

- [ ] All tests have passed locally after running `go test ./...`
- [ ] I have added tests that prove my fix or feature works as expected
- [ ] I have added any necessary documentation for my fix or feature

## Comments
Any further information you want to provide can go here.
