### PR TITLE
Initial Uninstaller and MacOS BugFixes

### DIFF
--- a/unixInstaller.sh
+++ b/unixInstaller.sh
@@ -17,7 +17,7 @@ then
 fi
 
 echo "Downloading the executable..."
-if [ $OSTYPE == *"darwin"* ]
+if [ -z "${OSTYPE##*darwin*}" ]
 then
     curl -L -o ~/bin/packageless https://github.com/everettraven/packageless/releases/latest/download/packageless-macos
 else
@@ -30,5 +30,5 @@ echo "Downloading packageless configuration file"
 curl -L -o ~/.packageless/config.hcl https://github.com/everettraven/packageless/releases/latest/download/config.hcl
 
 echo "Adding packageless to PATH by adding to: ~/."$shell"rc" 
-echo "export PATH=\$PATH:~/bin/" >> $HOME"/."$shell"rc"
+echo "export PATH=\$PATH:~/bin" >> $HOME"/."$shell"rc"
 echo "For changes to take effect, please restart your terminal"

--- a/unixuninstaller.sh
+++ b/unixuninstaller.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+echo "-------------------------"
+echo "- packageless uninstall -"
+echo "-------------------------"
+echo ""
+echo "removing packageless binary"
+rm -f ~/bin/packageless
+
+echo "removing .packageless folder"
+rm -f -r ~/.packageless
+
+#need to add a section here to clean up the rc file for the shell
+
+echo "removal complete"
+echo ""


### PR DESCRIPTION
fixes for mac path and detection

## Proposed Changes
Created initial uninstall for unix.
Fixed Mac OS detection for packageless binary install.  Also fixed the .rc file Path (removed trailing /)

## Type of Change
What kind of change to **packageless** is this?

- [x] Bug Fix
- [x] Feature
- [ ] Documentation
- [ ] Repository Enhancement
- [ ] Testing

## Checklist
Before the Pull Request can be considered for merging, the following Checklist should have the corresponding fields completed:

- [ ] All tests have passed locally after running `go test ./...`
- [x] I have added tests that prove my fix or feature works as expected
- [x] I have added any necessary documentation for my fix or feature

## Comments
Thank you for considering my change
