### PR TITLE
Added test for args length to subcommand

### DIFF
--- a/subcommands/subcommand_test.go
+++ b/subcommands/subcommand_test.go
@@ -200,3 +200,27 @@ func TestSubCommandUnknownSC(t *testing.T) {
 		}
 	}
 }
+
+func TestLengthArgs(t *testing.T) {
+	//Create a mock subcommand
+	msc := NewMockSC()
+
+	//Set the error message
+	msc.ErrorMsg = "Test error is being throw properly if the length of the args variable is < 1"
+
+	//Create an argument array
+	args := []string{}
+
+	//Create an array of Runner interface containing the mock subcommand
+	scmds := []Runner{
+		msc,
+	}
+
+	//Run the SubCommand function
+	err := SubCommand(args, scmds)
+
+	//Should have an error
+	if err == nil {
+		t.Fatalf("SubCommand: Expected to have error: %s | Received No Error", msc.ErrorMsg)
+	}
+}


### PR DESCRIPTION
## Proposed Changes
Issue + comment: https://github.com/everettraven/packageless/issues/51#issuecomment-1021899788

## Type of Change
What kind of change to **packageless** is this?

- [ ] Bug Fix
- [ ] Feature
- [ ] Documentation
- [ ] Repository Enhancement
- [x] Testing

## Checklist
Before the Pull Request can be considered for merging, the following Checklist should have the corresponding fields completed:

- [ ] All tests have passed locally after running `go test ./...`
- [x] I have added tests that prove my fix or feature works as expected
- [x] I have added any necessary documentation for my fix or feature

## Comments
Coverage for `subcommand.go` has reached 100%. I was able to get my test to succeed but not all of the other ones.  Might need some guidance on what I can do to get them all to work. I develop on Windows at the moment, so that might be contributing to the problem here.
