### PR TITLE
Added ability for install, uninstall and upgrade subcommands to take …

### DIFF
--- a/subcommands/subcommand.go
+++ b/subcommands/subcommand.go
@@ -20,15 +20,38 @@ func SubCommand(args []string, scmds []Runner) error {
 
 	subcommand := args[0]
 
+	args = args[1:]
+
 	for _, cmd := range scmds {
 		if cmd.Name() == subcommand {
-			err := cmd.Init(args[1:])
+			//Subcommands that take multiple pims as arguments
+			if subcommand == "install" || subcommand == "upgrade" || subcommand == "uninstall" {
+				//Execute subcommand for each pim in arguments
+				for _, pim := range args {
+					p := []string{pim}
+					err := cmd.Init(p)
 
-			if err != nil {
-				return err
+					if err != nil {
+						return err
+					}
+
+					err = cmd.Run()
+
+					if err != nil {
+						return err
+					}
+				}
+			} else {
+				err := cmd.Init(args)
+
+				if err != nil {
+					return err
+				}
+
+				return cmd.Run()
 			}
 
-			return cmd.Run()
+			return nil
 		}
 	}
 

--- a/subcommands/subcommand_test.go
+++ b/subcommands/subcommand_test.go
@@ -200,3 +200,84 @@ func TestSubCommandUnknownSC(t *testing.T) {
 		}
 	}
 }
+
+//Test the SubCommand function if multiple pims passed to install subcommand
+func TestSubCommandInstallMultiple(t *testing.T) {
+	//Create a mock subcommand
+	msc := NewMockSC()
+
+	//Set MockSC Values
+	msc.CmdName = "install"
+
+	sc := "install"
+
+	//Create an argument array
+	args := []string{sc, "python", "git"}
+
+	//Create an array of Runner interface containing the mock subcommand
+	scmds := []Runner{
+		msc,
+	}
+
+	//Run the SubCommand function
+	err := SubCommand(args, scmds)
+
+	//There shouldn't be an error
+	if err != nil {
+		t.Fatalf("SubCommand: Unexpected error: %s", err)
+	}
+}
+
+//Test the SubCommand function if multiple pims passed to uninstall subcommand
+func TestSubCommandUninstallMultiple(t *testing.T) {
+	//Create a mock subcommand
+	msc := NewMockSC()
+
+	//Set MockSC Values
+	msc.CmdName = "uninstall"
+
+	sc := "uninstall"
+
+	//Create an argument array
+	args := []string{sc, "python", "git"}
+
+	//Create an array of Runner interface containing the mock subcommand
+	scmds := []Runner{
+		msc,
+	}
+
+	//Run the SubCommand function
+	err := SubCommand(args, scmds)
+
+	//There shouldn't be an error
+	if err != nil {
+		t.Fatalf("SubCommand: Unexpected error: %s", err)
+	}
+}
+
+//Test the SubCommand function if multiple pims passed to upgrade subcommand
+func TestSubCommandUpgradeMultiple(t *testing.T) {
+	//Create a mock subcommand
+	msc := NewMockSC()
+
+	//Set MockSC Values
+	msc.CmdName = "upgrade"
+
+	sc := "upgrade"
+
+	//Create an argument array
+	args := []string{sc, "python", "git"}
+
+	//Create an array of Runner interface containing the mock subcommand
+	scmds := []Runner{
+		msc,
+	}
+
+	//Run the SubCommand function
+	err := SubCommand(args, scmds)
+
+	//There shouldn't be an error
+	if err != nil {
+		t.Fatalf("SubCommand: Unexpected error: %s", err)
+	}
+}


### PR DESCRIPTION
…multiple pims as arguments

## Proposed Changes
Enables users to install/uninstall/upgrade multiple pims with one command.
Examples:
`packageless install python dotnet git`

`packageless uninstall python dotnet git`

## Type of Change
What kind of change to **packageless** is this?

- [ ] Bug Fix
- [x] Feature
- [ ] Documentation
- [ ] Repository Enhancement
- [ ] Testing

## Checklist
Before the Pull Request can be considered for merging, the following Checklist should have the corresponding fields completed:

- [x] All tests have passed locally after running `go test ./...`
- [x] I have added tests that prove my fix or feature works as expected
- [ ] I have added any necessary documentation for my fix or feature

## Comments
I believe this to be the cleanest approach to implementing this feature without making fairly large changes to the individual subcommand's Run methods. The part I don't love about this approach is that it introduces subcommand specific logic into the generic subcommand interface. I am open to suggestions on a better approach!
