### PR TITLE
bug-fix for docker utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ python
 packageless.exe
 macros.doskey
 packageless
+*.out

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -49,6 +49,12 @@ func (u *Utility) ImageExists(imageID string, cli Client) (bool, error) {
 
 	//Loop through all the images and check if a match is found
 	for _, image := range images {
+
+		// If RepoTags returned isnt populated then skip to the next image
+		if len(image.RepoTags) < 1 {
+			continue
+		}
+
 		if image.RepoTags[0] == imageID {
 			return true, nil
 		}

--- a/utils/docker_test.go
+++ b/utils/docker_test.go
@@ -166,6 +166,44 @@ func TestImageExistError(t *testing.T) {
 	}
 }
 
+//Test ImageExists function when RepoTags is not populated
+func TestImageExistContinueOnEmptyRepoTag(t *testing.T) {
+	//Create the Mock Docker Client
+	dm := NewDockMock()
+
+	//Set the image for testing
+	img := "image:faketag"
+
+	//Set the return images array in the Mock Docker Client
+	dm.ILRet = []types.ImageSummary{
+		// First one should be an empty RepoTags
+		{
+			RepoTags: []string{},
+		},
+		// When image loop continues it should find this one.
+		{
+			RepoTags: []string{"image:faketag"},
+		},
+	}
+
+	//Create a new utility
+	util := NewUtility()
+
+	//Check for the image
+	exists, err := util.ImageExists(img, dm)
+
+	//If an error occurs, the test fails
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//The image should exist in this case
+	if !exists {
+		t.Fatal("ImageExists: Image should exist, but it does not.")
+	}
+
+}
+
 //Test CreateContainer Function
 func TestCreateContainer(t *testing.T) {
 	//Create the Mock Docker Client


### PR DESCRIPTION
## Proposed Changes
Modifies the docker utility function `ImageExists` to check the length of the RepoTags array on an Image object prior to indexing the array. This will prevent tests from failing due to an index out of range exception.

resolves #54 

## Type of Change
What kind of change to **packageless** is this?

- [x] Bug Fix
- [ ] Feature
- [ ] Documentation
- [ ] Repository Enhancement
- [ ] Testing

## Checklist
Before the Pull Request can be considered for merging, the following Checklist should have the corresponding fields completed:

- [x] All tests have passed locally after running `go test ./...`
- [x] I have added tests that prove my fix or feature works as expected
- [x] I have added any necessary documentation for my fix or feature

## Comments
Any further information you want to provide can go here.
