### PR TITLE
Added tests for empty volume paths

### DIFF
--- a/subcommands/run_sc.go
+++ b/subcommands/run_sc.go
@@ -3,7 +3,6 @@ package subcommands
 import (
 	"errors"
 	"flag"
-	"os"
 	"strconv"
 	"strings"
 
@@ -153,7 +152,7 @@ func (rc *RunCommand) Run() error {
 		if vol.Path != "" {
 			volumes = append(volumes, pimDir+vol.Path+":"+vol.Mount)
 		} else {
-			sourcePath, err := os.Getwd()
+			sourcePath, err := rc.tools.Getwd()
 
 			if err != nil {
 				return err

--- a/subcommands/run_sc_test.go
+++ b/subcommands/run_sc_test.go
@@ -633,3 +633,104 @@ func TestRunFileNotExists(t *testing.T) {
 		t.Fatalf("Call Stack does not match the expected call stack. Call Stack: %v | Expected Call Stack: %v", mu.Calls, callStack)
 	}
 }
+
+func TestRunEmptyVolumePath(t *testing.T) {
+	mu := utils.NewMockUtility()
+
+	mu.ImgExist = true
+
+	mu.Pim.Pims[0].Versions[0].Volumes[0].Path = ""
+
+	config := utils.Config{
+		BaseDir:        "~/.packageless/",
+		StartPort:      3000,
+		PortInc:        1,
+		Alias:          true,
+		RepositoryHost: "https://raw.githubusercontent.com/everettraven/packageless-pims/main/pims/",
+		PimsConfigDir:  "pims_config/",
+		PimsDir:        "pims/",
+	}
+
+	rc := NewRunCommand(mu, config)
+
+	args := []string{"python"}
+
+	err := rc.Init(args)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = rc.Run()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	//Set a variable with the proper call stack and see if the call stack matches
+	callStack := []string{
+		"FileExists",
+		"GetHCLBody",
+		"ParseBody",
+		"ImageExists",
+		"Getwd",
+		"RunContainer",
+	}
+
+	if !reflect.DeepEqual(callStack, mu.Calls) {
+		t.Fatalf("Call Stack does not match the expected call stack. Call Stack: %v | Expected Call Stack: %v", mu.Calls, callStack)
+	}
+}
+
+func TestRunErrorAtGetwd(t *testing.T) {
+	mu := utils.NewMockUtility()
+
+	mu.ImgExist = true
+
+	mu.ErrorAt = "Getwd"
+
+	mu.Pim.Pims[0].Versions[0].Volumes[0].Path = ""
+
+	config := utils.Config{
+		BaseDir:        "~/.packageless/",
+		StartPort:      3000,
+		PortInc:        1,
+		Alias:          true,
+		RepositoryHost: "https://raw.githubusercontent.com/everettraven/packageless-pims/main/pims/",
+		PimsConfigDir:  "pims_config/",
+		PimsDir:        "pims/",
+	}
+
+	rc := NewRunCommand(mu, config)
+
+	args := []string{"python"}
+
+	err := rc.Init(args)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = rc.Run()
+
+	if err == nil {
+		t.Fatal("Expected the following error: " + mu.ErrorMsg + " but did not receive an error")
+	}
+
+	if err.Error() != mu.ErrorMsg {
+		t.Fatal("Expected the following error: " + mu.ErrorMsg + "| Received: " + err.Error())
+	}
+
+	//Set a variable with the proper call stack and see if the call stack matches
+	callStack := []string{
+		"FileExists",
+		"GetHCLBody",
+		"ParseBody",
+		"ImageExists",
+		"Getwd",
+	}
+
+	if !reflect.DeepEqual(callStack, mu.Calls) {
+		t.Fatalf("Call Stack does not match the expected call stack. Call Stack: %v | Expected Call Stack: %v", mu.Calls, callStack)
+	}
+}

--- a/utils/mocks.go
+++ b/utils/mocks.go
@@ -399,6 +399,17 @@ func (mu *MockUtility) GetListOfInstalledPimConfigs(pimConfigDir string) ([]stri
 	return mu.InstalledPims, nil
 }
 
+//Mock of the Getwd Utility function
+func (mu *MockUtility) Getwd() (dir string, err error) {
+	mu.Calls = append(mu.Calls, "Getwd")
+
+	if mu.ErrorAt == "Getwd" {
+		return "", errors.New(mu.ErrorMsg)
+	}
+
+	return os.Getwd()
+}
+
 //Create a Mock for the Docker client
 type DockMock struct {
 	//Variable to know what function to return an error from

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -51,6 +51,7 @@ type Tools interface {
 	FileExists(path string) bool
 	RemoveFile(path string) error
 	GetListOfInstalledPimConfigs(pimConfigDir string) ([]string, error)
+	Getwd() (string, error)
 }
 
 //Utility Tool struct with its functions
@@ -253,6 +254,11 @@ func (u *Utility) GetListOfInstalledPimConfigs(pimConfigDir string) ([]string, e
 	}
 
 	return pimNames, nil
+}
+
+//Getwd returns a rooted path name corresponding to the current directory
+func (u *Utility) Getwd() (string, error) {
+	return os.Getwd()
 }
 
 //Create an interface to house the CopyFiles implementation. This will allow us to make a mock of the CopyFiles Function.


### PR DESCRIPTION
## Proposed Changes
Issue + Comment: https://github.com/everettraven/packageless/issues/51#issuecomment-1022851968

## Type of Change
- [ ] Bug Fix
- [ ] Feature
- [ ] Documentation
- [ ] Repository Enhancement
- [x] Testing

## Checklist
Before the Pull Request can be considered for merging, the following Checklist should have the corresponding fields completed:

- [x] All tests have passed locally after running `go test ./...`
- [x] I have added tests that prove my fix or feature works as expected
- [x] I have added any necessary documentation for my fix or feature

## Comments
I had to come up with a `MockUtility` function to simulate a `Getwd` error because otherwise supplying an empty string for the path still succeeds.

This will push `run_sc` up to 98.4% coverage
