### PR TITLE
Add test to assert unexpected type passed to ParseBody

### DIFF
--- a/utils/hcl_parse_test.go
+++ b/utils/hcl_parse_test.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/hashicorp/hcl2/hcl"
 	"github.com/hashicorp/hcl2/hclparse"
 )
 
@@ -289,31 +290,8 @@ func TestParseBodyPackageNoCopy(t *testing.T) {
 }
 
 func TestParseBodyReturnErrorWhenTypeIsUnexpected(t *testing.T) {
-	//Create the HCL byte array
-	hcl := []byte(`base_dir="./"
-	start_port=3000
-	port_increment=1
-	alias=true
-	repository_host="host.com"
-	pims_config_dir="pims_config"
-	pims_dir = "pims"`)
-
-	//Create the parser
-	parser := hclparse.NewParser()
-
-	//Parse the byte array
-	f, diags := parser.ParseHCL(hcl, "config_test")
-
-	//If error it fails
-	if diags.HasErrors() {
-		t.Fatal(diags.Error())
-	}
-
-	//Create a new utility
-	util := NewUtility()
-
 	//Parse the HCL Body
-	_, err := util.ParseBody(f.Body, nil)
+	_, err := NewUtility().ParseBody(hcl.EmptyBody(), nil)
 
 	//Return error because of invalid type (nil)
 	if err == nil {

--- a/utils/hcl_parse_test.go
+++ b/utils/hcl_parse_test.go
@@ -288,6 +288,44 @@ func TestParseBodyPackageNoCopy(t *testing.T) {
 	}
 }
 
+func TestParseBodyReturnErrorWhenTypeIsUnexpected(t *testing.T) {
+	//Create the HCL byte array
+	hcl := []byte(`base_dir="./"
+	start_port=3000
+	port_increment=1
+	alias=true
+	repository_host="host.com"
+	pims_config_dir="pims_config"
+	pims_dir = "pims"`)
+
+	//Create the parser
+	parser := hclparse.NewParser()
+
+	//Parse the byte array
+	f, diags := parser.ParseHCL(hcl, "config_test")
+
+	//If error it fails
+	if diags.HasErrors() {
+		t.Fatal(diags.Error())
+	}
+
+	//Create a new utility
+	util := NewUtility()
+
+	//Parse the HCL Body
+	_, err := util.ParseBody(f.Body, nil)
+
+	//Return error because of invalid type (nil)
+	if err == nil {
+		t.Fatal("ParseBody: Expected to receive an error, but did not receive one.")
+	}
+
+	expectedErrMsg := "Unexpected type passed into the HCL parse function"
+	if err.Error() != expectedErrMsg {
+		t.Fatal("ParseBody: Expected Error: " + expectedErrMsg + " | Received Error: " + err.Error())
+	}
+}
+
 // Integration Tests For HCL Parsing
 //-----------------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Proposed Changes
This PR will assert case when an unexpected type is passed to `ParseBody`, as mentioned in [#51 (comment)](https://github.com/everettraven/packageless/issues/51#issuecomment-1025133682).

## Type of Change
What kind of change to **packageless** is this?

- [ ] Bug Fix
- [ ] Feature
- [ ] Documentation
- [ ] Repository Enhancement
- [x] Testing

## Checklist
Before the Pull Request can be considered for merging, the following Checklist should have the corresponding fields completed:

- [x] All tests have passed locally after running `go test ./...`
- [x] I have added tests that prove my fix or feature works as expected
- [ ] I have added any necessary documentation for my fix or feature